### PR TITLE
Change ‘popular’ to ‘bypopularity’ (#33).

### DIFF
--- a/models/anime.rb
+++ b/models/anime.rb
@@ -254,7 +254,7 @@ module Railgun
       nokogiri = MALNetworkService.nokogiri_from_request(MALNetworkService.anime_rank_request(options[:type], options[:rank]))
 
       scraper = AnimeListScraper.new
-      scraper.scrape(nokogiri)
+      scraper.scrape(nokogiri, options[:type])
     end
 
   end

--- a/railgun.rb
+++ b/railgun.rb
@@ -15,7 +15,7 @@ require_relative 'utilities/logger'
 
 module Railgun
 
-  # Most current API version.
+  # Current API version.
   API_VERSION = '1.1'
 
   # Raised when there are any network errors.

--- a/scrapers/anime_list_scraper.rb
+++ b/scrapers/anime_list_scraper.rb
@@ -21,31 +21,7 @@ module Railgun
       end_date = parse_end_date(nokogiri)
       member_count = parse_member_count(nokogiri)
 
-      rank_type = ''
-
-      # Available options: 'all', 'airing', 'upcoming', 'tv', 'movie', 'ova', 'special', 'popular', 'favorite'.
-      case list_type
-        when 'all'
-          rank_type = 'rank'
-        when 'airing'
-          rank_type = 'airing_rank'
-        when 'upcoming'
-          rank_type = 'upcoming_rank'
-        when 'tv'
-          rank_type = 'tv_rank'
-        when 'movie'
-          rank_type = 'movie_rank'
-        when 'ova'
-          rank_type = 'ova_rank'
-        when 'special'
-          rank_type = 'special_rank'
-        when 'popular'
-          rank_type = 'popularity_rank'
-        when 'favorite'
-          rank_type = 'favorited_rank'
-        else
-
-      end
+      rank_type = rank_key(list_type)
 
       {
           id: id,
@@ -63,6 +39,39 @@ module Railgun
               member_count: member_count
           }
       }
+
+    end
+
+    # Takes a list type param and converts it to the appropriate
+    # JSON key. This is a _safe_ method in that it will default
+    # to 'rank' if the list_type does not match any appropriate
+    # key (however, this should have already been guarded before the request,
+    # so you must have _really_ messed up if you got to this state).
+    def rank_key(list_type)
+
+      # Available options: 'all', 'airing', 'upcoming', 'tv', 'movie', 'ova', 'special', 'popular', 'favorite'.
+      case list_type
+        when 'all'
+          'rank'
+        when 'airing'
+          'airing_rank'
+        when 'upcoming'
+          'upcoming_rank'
+        when 'tv'
+          'tv_rank'
+        when 'movie'
+          'movie_rank'
+        when 'ova'
+          'ova_rank'
+        when 'special'
+          'special_rank'
+        when 'popular'
+          'popularity_rank'
+        when 'favorite'
+          'favorited_rank'
+        else
+          'rank'
+      end
 
     end
 

--- a/scrapers/anime_list_scraper.rb
+++ b/scrapers/anime_list_scraper.rb
@@ -4,7 +4,7 @@ module Railgun
 
   class AnimeListScraper < ListScraper
 
-    def parse_row(nokogiri)
+    def parse_row(nokogiri, list_type)
       # Each row has five objects, three of which are useful:
       # 1: Rank
       # 2: Image, Name, Type (Episode Count), Air Date, Members
@@ -21,6 +21,32 @@ module Railgun
       end_date = parse_end_date(nokogiri)
       member_count = parse_member_count(nokogiri)
 
+      rank_type = ''
+
+      # Available options: 'all', 'airing', 'upcoming', 'tv', 'movie', 'ova', 'special', 'popular', 'favorite'.
+      case list_type
+        when 'all'
+          rank_type = 'rank'
+        when 'airing'
+          rank_type = 'airing_rank'
+        when 'upcoming'
+          rank_type = 'upcoming_rank'
+        when 'tv'
+          rank_type = 'tv_rank'
+        when 'movie'
+          rank_type = 'movie_rank'
+        when 'ova'
+          rank_type = 'ova_rank'
+        when 'special'
+          rank_type = 'special_rank'
+        when 'popular'
+          rank_type = 'popularity_rank'
+        when 'favorite'
+          rank_type = 'favorited_rank'
+        else
+
+      end
+
       {
           id: id,
           name: name,
@@ -33,7 +59,7 @@ module Railgun
           end_date: end_date,
 
           stats: {
-              rank: rank,
+              rank_type => rank,
               member_count: member_count
           }
       }

--- a/scrapers/list_scraper.rb
+++ b/scrapers/list_scraper.rb
@@ -46,12 +46,25 @@ module Railgun
 
     def parse_type(nokogiri)
       type_element = parse_metadata(nokogiri).first
-      $1 if type_element.match %r{([a-zA-Z]+) \([0-9]+ eps\)}
+
+      # We anticipate something of the format:
+      # TV (24 eps)
+      # However, sometimes episodes may be undefined (?).
+      $1 if type_element.match %r{([a-zA-Z]+) \(([0-9]+|\?) eps\)}
     end
 
     def parse_episodes(nokogiri)
       type_element = parse_metadata(nokogiri).first
-      $1.to_i if type_element.match %r{[a-zA-Z]+ \(([0-9]+) eps\)}
+
+      # We anticipate something of the format:
+      # TV (24 eps)
+      # However, sometimes episodes may be undefined (?).
+      # Return 0 in this instance.
+      if type_element.match %r{[a-zA-Z]+ \(([0-9]+) eps\)}
+        $1.to_i
+      else
+        0
+      end
     end
 
     def parse_start_date(nokogiri)

--- a/scrapers/list_scraper.rb
+++ b/scrapers/list_scraper.rb
@@ -4,13 +4,13 @@ module Railgun
 
   class ListScraper < Scraper
 
-    def scrape(nokogiri)
+    def scrape(nokogiri, options)
       resources = []
 
       # Find the table.
       table = nokogiri.xpath('//div[@id="content"]/div/table')
       table.xpath('//tr[@class="ranking-list"]').each do |tr|
-        resources << parse_row(tr)
+        resources << parse_row(tr, options)
       end
 
       resources

--- a/services/mal_network_service.rb
+++ b/services/mal_network_service.rb
@@ -110,7 +110,14 @@ module Railgun
     def self.anime_rank_request(type, page)
       request = 'https://myanimelist.net/topanime.php'
       if rank_type_is_acceptable_for_anime_request(type)
-        request += "?type=#{type}"
+
+        case type
+          when 'popular'
+            request += '?type=bypopularity'
+          else
+            request += "?type=#{type}"
+        end
+
       else
         request += '?type=all'
       end

--- a/test/html/popular_anime_response.html
+++ b/test/html/popular_anime_response.html
@@ -1,0 +1,1896 @@
+
+
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+
+<html>
+<head>
+
+
+<title>
+  Top Anime - Most Popular - MyAnimeList.net
+</title>
+<meta name="description" content="Browse the most popular anime on MyAnimeList, the internet&#039;s largest anime database." />
+
+
+<meta name="keywords" content="anime, myanimelist, anime news, manga" />
+
+
+
+
+
+  <link rel="next" href="https://myanimelist.net/topanime.php?type=bypopularity&amp;limit=50" />
+
+
+
+
+<meta property="og:locale" content="en_US"><meta property="fb:app_id" content="360769957454434"><meta property="og:site_name" content="MyAnimeList.net"><meta name="twitter:card" content="summary"><meta name="twitter:site" content="@myanimelist"><meta property="og:title" content=" Top Anime - Most Popular - MyAnimeList.net "><meta property="og:image" content="https://myanimelist.cdn-dena.com/img/sp/icon/apple-touch-icon-256.png"><meta name="twitter:image:src" content="https://myanimelist.cdn-dena.com/img/sp/icon/apple-touch-icon-256.png"><meta property="og:url" content="https://myanimelist.net/topanime.php?type=bypopularity"><meta property="og:description" content="Browse the most popular anime on MyAnimeList, the internet&#039;s largest anime database.">
+<link rel="manifest" href="/manifest.json">
+
+<meta name='csrf_token' content='857dad71a99ea8dc85d82b14f4d27e6cbc8bee92'><link rel="stylesheet" type="text/css" href="https://myanimelist.cdn-dena.com/static/assets/css/pc/style-d3f2f67ab8.css" />
+
+<script type="text/javascript" src="https://myanimelist.cdn-dena.com/static/assets/js/pc/header-372c33dc23.js"></script>
+<script type="text/javascript" src="https://myanimelist.cdn-dena.com/static/assets/js/pc/all-4b21fd9dfb.js"
+        id="alljs" data-params='{&quot;origin_url&quot;:&quot;https:\/\/myanimelist.net&quot;,&quot;is_request_bot_filter_log&quot;:false}' defer></script>
+
+
+
+<link rel="search" type="application/opensearchdescription+xml" href="https://myanimelist.net/plugins/myanimelist.xml" title="MyAnimeList" />
+
+<link rel="shortcut icon" href="https://myanimelist.cdn-dena.com/images/faviconv5.ico" />
+
+<script>
+  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+  })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+  ga('create', 'UA-369102-1', 'auto');
+  ga('require', 'linkid'); // Enhanced Link Attribution
+  ga('send', 'pageview');
+</script>
+  <!-- ### Load GPT Library ### -->
+<script type='text/javascript'>
+ var googletag = googletag || {};
+  googletag.cmd = googletag.cmd || [];
+  (function() {
+    var gads = document.createElement('script');
+    gads.async = true;
+    gads.type = 'text/javascript';
+    var useSSL = 'https:' == document.location.protocol;
+    gads.src = (useSSL ? 'https:' : 'http:') +
+               '//www.googletagservices.com/tag/js/gpt.js';
+    var node = document.getElementsByTagName('script')[0];
+    node.parentNode.insertBefore(gads, node);
+  })();</script>
+<script src="https://apis.google.com/js/platform.js" async defer>{lang: 'en-GB'}</script>
+<script src="https://www.google.com/recaptcha/api.js?hl=en"></script>
+
+
+</head>
+
+<body onload=" " class="page-common">
+<div id="myanimelist">
+
+
+
+        <div class="_unit " style="width:1px;display: block !important;" data-height="1">
+      <div id="skin_detail" class="" style="width:1px;">
+        <script type='text/javascript'>
+          googletag.cmd.push(function() {
+                      var slot = googletag.defineOutOfPageSlot("/84947469/skin_detail", "skin_detail").addService(googletag.pubads())
+      .setTargeting("adult", "white").setCollapseEmptyDiv(true,true);googletag.enableServices();
+
+      googletag.display("skin_detail");
+              });</script>
+      </div>
+    </div>
+    <script type='text/javascript'>
+    window.MAL.SkinAd.prepareForSkin('skin_detail');
+  </script>
+
+    <div id="ad-skin-bg-left" class="ad-skin-side-outer ad-skin-side-bg bg-left">
+    <div id="ad-skin-left" class="ad-skin-side left" style="display: none;">
+      <div id="ad-skin-left-absolute-block">
+        <div id="ad-skin-left-fixed-block"></div>
+      </div>
+    </div>
+  </div>
+        <div class="wrapper aprilfools"><div id="headerSmall" class="aprilfools"><a href="/panel.php" class="link-mal-logo">MyAnimeList.net</a>
+
+<a href="https://myanimelist.net/account/membership?_location=mal_h_b&amp;_type=2"
+   class="banner-header-anime-straming" target="_self">
+  <img src="https://myanimelist.cdn-dena.com/images/membership/banner.gif?v=1" width="250" height="36"
+       srcset="https://myanimelist.cdn-dena.com/images/membership/banner.gif?v=1 1x, https://myanimelist.cdn-dena.com/images/membership/banner@2x.gif?v=1 2x"
+       alt="Become a MAL Supporter" title="Become a MAL Supporter">
+</a>
+
+<div id="header-menu" class="pulldown"><div class="header-menu-unit header-list js-header-menu-unit" data-id="list"><a class="header-list-button " title="List"><i class="fa fa-list"></i></a><div class="header-menu-dropdown header-list-dropdown arrow_box"><ul><li><a href="https://myanimelist.net/animelist/SpacePyro">Anime List</a></li><li><a href="https://myanimelist.net/mangalist/SpacePyro">Manga List</a></li><li><a href="https://myanimelist.net/addtolist.php">Quick Add</a></li><li><a href="https://myanimelist.net/editprofile.php?go=listpreferences">List Settings</a></li></ul></div></div><div class="border"></div><div class="header-menu-unit header-message js-header-menu-unit" data-id="message"><a href="https://myanimelist.net/mymessages.php"
+         data-unread="0"
+         class="header-message-button
+           "
+         title="Messages"><i class="fa fa-envelope"></i></a></div><div class="border"></div><div class="header-menu-unit header-notification"><div class="js-header-notification"></div></div><script>
+window.MAL.headerNotification = {"countDigest":1,"dropdownOpenedAt":1490546177,"hasNewItems":true};
+window.MAL.headerNotification.templates = {"root":"  <div>\n    <header-notification-button\n      :has-not-seen=\"hasNotSeenItems\"\n      :is-dropdown-visible=\"isDropdownVisible\"\n      :on-click=\"toggleDropdown\"\n      :num-whole-unread-items=\"numWholeUnreadItems\">\n    <\/header-notification-button>\n    <header-notification-dropdown\n      :items=\"items\"\n      :items-checked-in-this-session=\"itemsCheckedInThisSession\"\n      :num-whole-unread-items=\"numWholeUnreadItems\"\n      :dropdown-opened-at=\"dropdownOpenedAt\"\n      :is-visible=\"isDropdownVisible\"\n      :was-dropdown-closed=\"wasDropdownClosed\"\n      :is-loaded=\"isLoaded\"\n      v-on:checkItems=\"checkItems\"\n      v-on:acceptFriendRequests=\"acceptFriendRequests\"\n      v-on:denyFriendRequests=\"denyFriendRequests\"\n    >\n    <\/header-notification-dropdown>\n  <\/div>\n  ","button":"    <a class=\"header-notification-button\"\n      :class=\"[(hasUnread ? 'has-unread' : ''), (hasNotSeen ? 'new' : ''), ('text' + numWholeUnreadItemsAsString.length)]\"\n      @click=\"onClick\"\n      @keypress.enter=\"onClick\"\n      :aria-expanded=\"isDropdownVisible ? 'true' : 'false'\"\n      aria-haspopup=\"true\"\n      aria-label=\"Notifications\"\n      title=\"Notifications\"\n      tabindex=\"0\"\n            :data-unread=\"numWholeUnreadItemsAsString\">\n      <i class=\"fa fa-bell\"><\/i>\n    <\/a>\n  ","dropdown":"    <div class=\"header-notification-dropdown\" v-show=\"isVisible\">\n      <div class=\"arrow_box\">\n        <div class=\"header-notification-dropdown-inner\">\n          <h3>\n            <span class=\"settings ml8\">\n              <a href=\"\/notification\/setting\">\n                <i class=\"fa fa-cog mr4\"><\/i>Settings\n              <\/a>\n            <\/span>\n            <span class=\"mark-all\"\n              :class=\"{disabled: !hasUnreadItems}\"\n              @click=\"checkAllItems\">\n              <i class=\"fa fa-check mr4\"><\/i>Mark All as Read\n            <\/span>\n            Notifications\n          <\/h3>\n          <ol class=\"header-notification-item-list\">\n            <li class=\"header-notification-item\"\n              :class=\"[item.typeIdentifier, isNewItem(item) ? 'new' : '']\"\n              v-for=\"item in items\">\n              <a v-if=\"item.url\" @click=\"checkItem(item)\" :href=\"item.url\" class=\"background\"><\/a>\n              <div class=\"inner\"\n                :class=\"{'is-read': item.isRead && !isItemCheckedInThisSession(item)}\">\n                <div class=\"header-notification-item-header\">\n                                    <span class=\"is-read\"\n                    v-show=\"!item.isRead || isItemCheckedInThisSession(item)\"\n                    :class=\"{checked: item.isRead}\"\n                    @click=\"checkItem(item)\">\n                    <i class=\"fa fa-check\"><\/i>\n                    <i class=\"fa fa-check-circle\"><\/i>\n                  <\/span>\n                                    <span class=\"time\">${item.createdAtForDisplay}<\/span>\n                                    <span class=\"category\">${item.categoryName}<\/span>\n                <\/div>\n                                <div class=\"header-notification-item-content\"\n                  :class=\"[item.typeIdentifier]\" :on-check-item=\"checkItem\">\n                                    <component :is=\"resolveComponent(item)\"\n                    v-if=\"!item.isDeleted\"\n                    v-on:acceptFriendRequest=\"acceptFriendRequest\"\n                    v-on:denyFriendRequest=\"denyFriendRequest\"\n                    :item=\"item\"\n                    >\n                  <\/component>\n                  <div class=\"deleted\" v-if=\"item.isDeleted\">(deleted)<\/div>\n                <\/div>\n              <\/div>\n            <\/li>\n            <li class=\"header-notification-item empty\" v-if=\"isLoaded && items.length === 0\">\n              <p>No notifications.<\/p>\n            <\/li>\n            <li class=\"header-notification-item empty\" v-if=\"!isLoaded\">\n              <i class=\"fa fa-spinner fa-spin fa-2x fa-fw\" style=\"width:100%;color:#bbb;\"><\/i>\n            <\/li>\n          <\/ol>\n          <div class=\"header-notification-view-all\">\n            <a href=\"https:\/\/myanimelist.net\/notification\">\n              View All\n              <span v-if=\"numWholeUnreadItems > 0\">\n                (${numWholeUnreadItems &lt; 100 ? numWholeUnreadItems : &quot;99+&quot;})\n              <\/span>\n            <\/a>\n          <\/div>\n        <\/div>\n      <\/div>\n    <\/div>\n  ","itemFriendRequest":"    <div>\n      <p>\n        <a :href=\"item.friendProfileUrl\" class=\"fl-l mr4\"><img :src=\"item.friendImageUrl\" :alt=\"item.friendName\"><\/a>\n        <a :href=\"item.friendProfileUrl\">${item.friendName}<\/a>\n        sent you a friend request${item.message.length ? \":\" : \".\"}\n        <q class=\"message\" v-if=\"item.message.length\">${item.message}<\/q>\n      <\/p>\n      <p class=\"actions mt8\">\n        <span v-if=\"!item.isApproved\">\n          <span class=\"action-button accept\" @click=\"accept\">Accept<\/span><span class=\"action-button deny\" @click=\"deny\">Deny<\/span><\/span>\n        <span v-if=\"item.isApproved\">\n          <span class=\"result\">Accepted<\/span>\n        <\/span>\n      <\/p>\n    <\/div>\n  ","itemFriendRequestAccept":"    <p>\n      <a :href=\"item.friendProfileUrl\" class=\"fl-l mr4\"><img :src=\"item.friendImageUrl\" :alt=\"item.friendName\"><\/a>\n      <a :href=\"item.friendProfileUrl\">${item.friendName}<\/a>\n      accepted your friend request.\n    <\/p>\n  ","itemFriendRequestDeny":"    <p>\n      <a :href=\"item.friendProfileUrl\" class=\"fl-l mr4\"><img :src=\"item.friendImageUrl\" :alt=\"item.friendName\"><\/a>\n      <a :href=\"item.friendProfileUrl\">${item.friendName}<\/a>\n      denied your friend request.\n    <\/p>\n  ","itemProfileComment":"    <span>\n      <a :href=\"item.commentUserProfileUrl\">${item.commentUserName}<\/a>\n      posted a comment on your profile${item.text.length ? \":\" : \".\"}\n      <q class=\"message\" v-if=\"item.text.length\">${item.text}<\/q>\n    <\/span>\n  ","itemForumQuote":"    <span>\n      <a :href=\"item.quoteUserProfileUrl\">${item.quoteUserName}<\/a>\n      quoted your post in the <a :href=\"item.topicUrl\">${item.topicTitle}<\/a> topic.\n    <\/span>\n  ","itemBlogComment":"    <span>\n      <a :href=\"item.quoteUserProfileUrl\">${item.quoteUserName}<\/a>\n      <a :href=\"item.commentUserProfileUrl\">${item.commentUserName}<\/a>\n      posted a comment on your blog.\n    <\/span>\n  ","itemWatchedTopicMessage":"    <span>\n      <a :href=\"item.quoteUserProfileUrl\">${item.quoteUserName}<\/a>\n      A forum reply was posted on your watched topic\n      <a :href=\"item.topicUrl\">${item.topicTitle}<\/a>.\n    <\/span>\n  ","itemClubMassMessageInForum":"    <span>\n      <a :href=\"item.quoteUserProfileUrl\">${item.quoteUserName}<\/a>\n      <a :href=\"item.sharedUserProfileUrl\">${item.sharedUserName}<\/a> shared the discussion\n      <a :href=\"item.topicUrl\" :title=\"item.topicTitle\">${item.topicTitle}<\/a>\n      in <a :href=\"item.clubUrl\" :title=\"item.clubName\">${item.clubName}<\/a>.\n    <\/span>\n  ","itemRelatedAnimeAdd":"    <span>\n      <a :href=\"item.url\">${item.anime.title}<\/a>&nbsp;(${item.anime.mediaType}) has just been added to the database.\n    <\/span>\n  ","itemPaymentStripe":"    <span>\n      <i>${item.planName}<\/i> has been suspended, because the payment for your subscription was unable to be processed.\n    <\/span>\n  ","itemUserMentions":"    <span>\n      <a :href=\"item.senderProfileUrl\">${item.senderName}<\/a>\n      has mentioned your name in the\n      <a :href=\"item.pageUrl\">${item.pageTitle}<\/a>\n      <span v-text=\"{\n        user_mention_in_forum_message: 'topic',\n        user_mention_in_club_comment: 'club'\n      }[item.typeIdentifier]\"><\/span>.\n    <\/span>\n  ","itemOnAir":"    <span>\n      The anime you plan to watch will begin airing on ${item.date}:\n      <span class=\"ml8 mt4\">\n        <template v-for=\"(anime, i) in item.animes\">\n          <a :href=\"anime.url\">${anime.title}<\/a><template v-if=\"i < item.animes.length - 1\">, <\/template>\n        <\/template>\n      <\/span>\n    <\/span>\n  "};
+</script><div class="border"></div><div class="header-menu-unit header-profile js-header-menu-unit link-bg pl8 pr8" data-id="profile"><a class="header-profile-link">SpacePyro<i class="fa fa-caret-down ml4"></i></a><div class="header-menu-dropdown header-profile-dropdown arrow_box"><ul><li><a href="https://myanimelist.net/profile/SpacePyro">Profile</a></li><li class="clearfix"><a href="/myfriends.php?go=pending"
+                 title="You have 3 friend requests."
+                 class="fl-r link-count">(3)</a><a href="https://myanimelist.net/myfriends.php">Friends</a></li><li class="clearfix"><a href="https://myanimelist.net/clubs.php?action=myclubs">Clubs</a></li><li><a href="https://myanimelist.net/blog/SpacePyro">Blog Posts</a></li><li><a href="https://myanimelist.net/myreviews.php">Reviews</a></li><li><a href="https://myanimelist.net/myrecommendations.php">Recommendations</a></li><li><a href="https://myanimelist.net/editprofile.php?go=myoptions"><i class="fa fa-cog mr4"></i>Account Settings</a></li><li><form action="https://myanimelist.net/logout.php" method="post"><a href="javascript:void(0);" onclick="$(this).parent().submit();"><i class="fa fa-sign-out mr4"></i>Logout</a></form></li></ul></div></div><div class="header-menu-unit header-profile pl0"><a href="https://myanimelist.net/profile/SpacePyro" class="header-profile-button" style="background-image:url(https://myanimelist.cdn-dena.com/images/userimages/1938074.webp)" title="SpacePyro"></a></div></div></div>  <div id="menu" class="aprilfools">
+    <div id="menu_right"><script type="text/x-template" id="incremental-result-item-anime"><div class="list anime" :class="{'focus': focus}"><a :href="url" class="clearfix"><div class="on" v-if="focus"><span class="image" :style="{'background-image': 'url(' + item.image_url + ')'}"></span><div class="info anime"><div class="name">${ item.name } <span class="media-type">(${ item.payload.media_type })</span></div><div class="extra-info">Aired: ${ item.payload.aired }<br>Score: ${ item.payload.score }<br>Status: ${ item.payload.status }</div></div></div><div class="off" v-if="!focus"><span class="image" :style="{'background-image': 'url(' + item.thumbnail_url + ')'}"></span><div class="info anime"><div class="name">${ item.name }</div><div class="media-type">(${ mediaTypeWithStartYear })</div></div></div></a></div></script><script type="text/x-template" id="incremental-result-item-manga"><div class="list manga" :class="{'focus': focus}"><a :href="url" class="clearfix"><div class="on" v-if="focus"><span class="image" :style="{'background-image': 'url(' + item.image_url + ')'}"></span><div class="info manga"><div class="name">${ item.name } <span class="media-type">(${ item.payload.media_type })</span></div><div class="extra-info">Published: ${ item.payload.published }<br>Score: ${ item.payload.score }<br>Status: ${ item.payload.status }</div></div></div><div class="off" v-if="!focus"><span class="image" :style="{'background-image': 'url(' + item.thumbnail_url + ')'}"></span><div class="info manga"><div class="name">${ item.name }</div><div class="media-type">(${ mediaTypeWithStartYear })</div></div></div></a></div></script><script type="text/x-template" id="incremental-result-item-character"><div class="list character" :class="{'focus': focus}"><a :href="url" class="clearfix"><div class="on" v-if="focus"><span class="image" :style="{'background-image': 'url(' + item.image_url + ')'}"></span><div class="info character"><div class="name">${ item.name }</div><div class="extra-info"><ul class="related-works"><li v-for="work in item.payload.related_works" class="fs-i">- ${ work }</li></ul>Favorites: ${ item.payload.favorites }</div></div></div><div class="off" v-if="!focus"><span class="image" :style="{'background-image': 'url(' + item.thumbnail_url + ')'}"></span><div class="info character"><div class="name">${ item.name }</div></div></div></a></div></script><script type="text/x-template" id="incremental-result-item-person"><div class="list person" :class="{'focus': focus}"><a :href="url" class="clearfix"><div class="on" v-if="focus"><span class="image" :style="{'background-image': 'url(' + item.image_url + ')'}"></span><div class="info person"><div class="name">${ item.name }</div><div class="extra-info"><span v-if="item.payload.alternative_name">${ item.payload.alternative_name }<br></span>Birthday: ${ item.payload.birthday }<br>Favorites: ${ item.payload.favorites }</div></div></div><div class="off" v-if="!focus"><span class="image" :style="{'background-image': 'url(' + item.thumbnail_url + ')'}"></span><div class="info person"><div class="name">${ item.name }</div></div></div></a></div></script><script type="text/x-template" id="incremental-result-item-club"><div class="list club" :class="{'focus': focus}"><a :href="url" class="clearfix"><div class="on" v-if="focus"><span class="image" :style="{'background-image': 'url(' + item.image_url + ')'}"></span><div class="info club"><div class="name">${ item.name }</div><div class="extra-info">Members: ${ item.payload.members }<br>Category: ${ item.payload.category }<br>Created by: ${ item.payload.created_by }</div></div></div><div class="off" v-if="!focus"><span class="image" :style="{'background-image': 'url(' + item.thumbnail_url + ')'}"></span><div class="info club"><div class="name">${ item.name }</div></div></div></a></div></script><script type="text/x-template" id="incremental-result-item-user"><div class="list user" :class="{'focus': focus}"><a :href="url" class="clearfix"><div class="on" v-if="focus"><span class="image" :style="{'background-image': 'url(' + item.image_url + ')'}"></span><div class="info user"><div class="name">${ item.name }</div><div class="extra-info"><span v-if="item.payload.authority">${ item.payload.authority }<br></span>Joined: ${ item.payload.joined }</div></div></div><div class="off" v-if="!focus"><span class="image" :style="{'background-image': 'url(' + item.thumbnail_url + ')'}"></span><div class="info user"><div class="name">${ item.name }</div></div></div></a></div></script><script type="text/x-template" id="incremental-result-item-news"><div class="list news" :class="{'focus': focus}"><a :href="url" class="clearfix"><div class="on" v-if="focus"><span class="image" :style="{'background-image': 'url(' + item.image_url + ')'}"></span><div class="info news"><div class="name">${ item.name }</div><div class="extra-info">${ item.payload.date }</div></div></div><div class="off" v-if="!focus"><span class="image" :style="{'background-image': 'url(' + item.thumbnail_url + ')'}"></span><div class="info news"><div class="name">${ item.name }</div><div class="media-type">${ item.payload.date }</div></div></div></a></div></script><script type="text/x-template" id="incremental-result-item-featured"><div class="list featured" :class="{'focus': focus}"><a :href="url" class="clearfix"><div class="on" v-if="focus"><span class="image" :style="{'background-image': 'url(' + item.image_url + ')'}"></span><div class="info featured"><div class="name">${ item.name }</div><div class="extra-info">${ item.payload.date }</div></div></div><div class="off" v-if="!focus"><span class="image" :style="{'background-image': 'url(' + item.thumbnail_url + ')'}"></span><div class="info featured"><div class="name">${ item.name }</div><div class="media-type">${ item.payload.date }</div></div></div></a></div></script><script type="text/x-template" id="incremental-result-item-forum"><div class="list forum" :class="{'focus': focus}"><a :href="url" class="clearfix"><div class="on" v-if="focus"><span class="image" :style="{'background-image': 'url(' + item.image_url + ')'}"></span><div class="info forum"><div class="name"><span v-show="item.payload.work_title">${ item.payload.work_title}
+                      <i class="fa fa-caret-right"></i></span> ${ item.name }</div><div class="extra-info">${ item.payload.date }<br><span>in ${ item.payload.category }</span></div></div></div><div class="off" v-if="!focus"><span class="image" :style="{'background-image': 'url(' + item.thumbnail_url + ')'}"></span><div class="info forum"><div class="name"><span v-show="item.payload.work_title">${ item.payload.work_title}
+                      <i class="fa fa-caret-right"></i></span> ${ item.name }</div><div class="media-type">${ item.payload.date }</div></div></div></a></div></script><script type="text/x-template" id="incremental-result-item-separator"><div class="list separator"><div class="separator"><span v-show="item.name == 'anime'">Anime</span><span v-show="item.name == 'manga'">Manga</span><span v-show="item.name == 'character'">Characters</span><span v-show="item.name == 'person'">People</span></div></div></script><div id="top-search-bar"><form id="searchBar" method="get" class="searchBar" @submit.prevent="jump()"><div class="form-select-outer fl-l"><select name="type" id="topSearchValue" class="inputtext" v-model="type"><option value="all">All</option><option value="anime">Anime</option><option value="manga">Manga</option><option value="character">Characters</option><option value="person">People</option><option value="news">News</option><option value="featured">Featured Articles</option><option value="forum">Forum</option><option value="club">Clubs</option><option value="user">Users</option></select></div><input v-model="keyword" id="topSearchText" type="text"
+            name="keyword" class="inputtext fl-l" placeholder="Search Anime, Manga, and more..."
+            size="30" autocomplete="off"
+            @keydown.up.prevent="moveSelection(-1)" @keydown.down.prevent="moveSelection(1)"
+            @focus="isFocused = true" @blur="isFocused = false"><input id="topSearchButon" class="fl-l" :class="{'notActive': (keyword.length < 3)}" type="submit" value="&#xf002"></form><div id="topSearchResultList" class="incrementalSearchResultList" :style="{display: (showResult ? 'block' : 'none')}" @mousedown.prevent=""><div v-for="(item, i) in items" @mouseover="selection=i"><component :is="resolveComponent(item)" :item="item" :focus="selection == i" :url="generateItemPageUrl(item)"></component></div><div class="list list-bottom" :class="{'focus': selection == -1}" @mouseover="selection = -1"
+               :style="{display: (showViewAllLink ? 'block' : 'none')}"><a :href="resultPageUrl">
+              View all results for <span class="fw-b">${ keyword }</span><i v-show="isRequesting" class="fa fa-spinner fa-spin ml4"></i></a></div></div></div></div><div id="menu_left">
+      <ul id="nav">
+        <li class="small"><a href="#" class="non-link">Anime</a>
+          <ul class="wider">
+            <li><a href="https://myanimelist.net/anime.php?_location=mal_h_m">Anime Search</a></li>
+            <li><a href="https://myanimelist.net/topanime.php?_location=mal_h_m">Top Anime</a></li>
+            <li><a href="https://myanimelist.net/anime/season?_location=mal_h_m">Seasonal Anime</a></li>
+                        <li><a href="https://myanimelist.net/watch/episode?_location=mal_h_m_a">Videos</a></li>
+            <li><a href="https://myanimelist.net/reviews.php?t=anime&amp;_location=mal_h_m">Reviews</a></li>
+            <li><a href="https://myanimelist.net/recommendations.php?s=recentrecs&amp;t=anime&amp;_location=mal_h_m">Recommendations</a></li>
+            <li><a href="https://myanimelist.net/forum?topicid=1582476&amp;_location=mal_h_m">2017 Challenge</a></li>
+          </ul>
+        </li>
+        <li class="small"><a href="#" class="non-link">Manga</a>
+          <ul class="wider">
+            <li><a href="https://myanimelist.net/manga.php?_location=mal_h_m">Manga Search</a></li>
+            <li><a href="https://myanimelist.net/topmanga.php?_location=mal_h_m">Top Manga</a></li>
+            <li><a href="https://myanimelist.net/reviews.php?t=manga&amp;_location=mal_h_m">Reviews</a></li>
+            <li><a href="https://myanimelist.net/recommendations.php?s=recentrecs&amp;t=manga&amp;_location=mal_h_m">Recommendations</a></li>
+            <li><a href="https://myanimelist.net/forum?topicid=1582478&amp;_location=mal_h_m">2017 Challenge</a></li>
+          </ul>
+        </li>
+        <li><a href="#" class="non-link">Community</a>
+          <ul>
+            <li><a href="https://myanimelist.net/forum/?_location=mal_h_m">Forums</a></li>
+            <li><a href="https://myanimelist.net/clubs.php?_location=mal_h_m">Clubs</a></li>
+            <li><a href="https://myanimelist.net/blog.php?_location=mal_h_m">Blogs</a></li>
+            <li><a href="https://myanimelist.net/users.php?_location=mal_h_m">Users</a></li>
+          </ul>
+        </li>
+        <li class="small2"><a href="#" class="non-link">Industry</a>
+          <ul class="wider">
+            <li><a href="https://myanimelist.net/news?_location=mal_h_m">News</a></li>
+            <li><a href="https://myanimelist.net/featured?_location=mal_h_m">Featured Articles</a></li>
+            <li><a href="https://myanimelist.net/people.php?_location=mal_h_m">People</a></li>
+            <li><a href="https://myanimelist.net/character.php?_location=mal_h_m">Characters</a></li>
+          </ul>
+        </li>
+        <li class="small"><a href="#" class="non-link">Watch</a>
+          <ul class="wider">
+            <li><a href="https://myanimelist.net/watch/episode?_location=mal_h_m">Episode Videos</a></li>
+            <li><a href="https://myanimelist.net/watch/promotion?_location=mal_h_m">Promotional Videos</a></li>
+                      </ul>
+        </li>
+        <li class="smaller"><a href="#" class="non-link">Help</a>
+          <ul class="wide">
+            <li><a href="https://myanimelist.net/about.php?_location=mal_h_m">About</a></li>
+            <li><a href="https://myanimelist.net/about.php?go=support&amp;_location=mal_h_m">Support</a></li>
+            <li><a href="https://myanimelist.net/advertising?_location=mal_h_m">Advertising</a></li>
+            <li><a href="https://myanimelist.net/forum/?topicid=515949&amp;_location=mal_h_m">FAQ</a></li>
+            <li><a href="https://myanimelist.net/modules.php?go=report&amp;_location=mal_h_m">Report</a></li>
+            <li><a href="https://myanimelist.net/about.php?go=team&amp;_location=mal_h_m">Staff</a></li><li><a href="https://myanimelist.net/membership?_location=mal_h_m">MAL Supporter</a></li>
+          </ul>
+        </li>
+
+        <li class="aprilfools">
+          <a href="https://myanimelist.net/shop" class="aprilfools">
+            Shop<i class="fa fa-shopping-cart fa-lg ml4" aria-hidden="true"></i>
+          </a>
+        </li>
+              </ul>
+    </div>  </div><div id="contentWrapper"><div><h1 class="h1">Top Anime</h1></div><div id="content">
+
+
+                                  <div class="breadcrumb " itemscope itemtype="http://schema.org/BreadcrumbList"><div class="di-ib" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem"><a href="https://myanimelist.net/" itemprop="item"><span itemprop="name">
+              Top
+                          </span></a><meta itemprop="position" content="1"></div>&nbsp; &gt; &nbsp;        <div class="di-ib" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem"><a href="https://myanimelist.net/anime.php" itemprop="item"><span itemprop="name">
+              Anime
+                          </span></a><meta itemprop="position" content="2"></div>&nbsp; &gt; &nbsp;        <div class="di-ib" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem"><a href="https://myanimelist.net/topanime.php" itemprop="item"><span itemprop="name">
+              Top Anime
+                          </span></a><meta itemprop="position" content="3"></div>&nbsp; &gt; &nbsp;        <div class="di-ib" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem"><a href="https://myanimelist.net/topanime.php?type=bypopularity" itemprop="item"><span itemprop="name">
+              Most Popular
+                          </span></a><meta itemprop="position" content="4"></div></div>
+
+
+
+
+
+<div id="horiznav_nav" class="horiznav_nav_list">
+<ul style="margin-right: 0; padding-right: 0;">
+<li><a href="topanime.php" >All Anime</a></li>
+<li><a  href="?type=airing">Top Airing</a></li>
+<li><a  href="?type=upcoming">Top Upcoming</a></li>
+<li><a  href="?type=tv">Top TV Series</a></li>
+<li><a  href="?type=movie">Top Movies</a></li>
+<li><a  href="?type=ova">Top OVAs</a></li>
+<li><a  href="?type=special">Top Specials</a></li>
+<li><a class="horiznav_active" href="?type=bypopularity">Most Popular</a></li>
+<li><a  href="?type=favorite">Most Favorited</a></li>
+</ul>
+</div>
+  <div class="pb12"><h2 class="fs18 fw-b ff-avenir mt24 top-rank-header2"><span class="fl-r di-ib icon-top-ranking-page"><a href="?type=bypopularity&limit=50" class="link-blue-box next">Next 50<i class="fa fa-chevron-right ml4"></i></a></span>Top Anime by Popularity<span class="fs10 fw-n ff-Verdana di-ib ml16">Updated twice a day. (<a href="javascript:void(0);" onclick="window.open('info.php?go=topanime','topanime','menubar=no,scrollbars=no,status=no,width=500,height=380');">How do we rank shows?</a>)</span></h2><table border="0" cellpadding="0" cellspacing="0" width="100%" class="top-ranking-table"><tr class="table-header"><td class="rank">Rank</td><td class="title">Title</td><td class="score">Score</td><td class="your-score">Your Score</td><td class="status">Status</td></tr>
+<tr class="ranking-list">
+    <td class="rank ac" valign="top">
+    <span class="lightLink top-anime-rank-text rank1">1</span>
+  </td>
+    <td class="title al va-t word-break">
+    <a class="hoverinfo_trigger fl-l ml12 mr8" href="https://myanimelist.net/anime/1535/Death_Note" id="#area1535" rel="#info1535">
+      <img width="50" height="70" alt="Anime: Death Note" class="lazyload" border="0" data-src="https://myanimelist.cdn-dena.com/r/50x70/images/anime/9/9453.webp?s=bcf651aae2cd301a32bcc46e317a98bc" data-srcset="https://myanimelist.cdn-dena.com/r/50x70/images/anime/9/9453.webp?s=bcf651aae2cd301a32bcc46e317a98bc 1x, https://myanimelist.cdn-dena.com/r/100x140/images/anime/9/9453.webp?s=2c98296ec8ff8181bacd2c34bdbdf9fb 2x" />
+    </a>
+
+    <div class="detail"><div id="area1535">
+  <div id="info1535" rel="a1535" class="hoverinfo"></div>
+</div>
+<div class="di-ib clearfix"><a class="hoverinfo_trigger fl-l fs14 fw-b" href="https://myanimelist.net/anime/1535/Death_Note" id="#area1535" rel="#info1535">Death Note</a><a href="https://myanimelist.net/anime/1535/Death_Note/video" class="icon-watch ml8" title="Watch Episode Video">Watch Episode Video</a></div><br><div class="information di-ib mt4">
+        TV (37 eps)<br>
+        Oct 2006 - Jun 2007<br>
+        1,097,068 members
+      </div></div>
+  </td>
+
+    <td class="score ac fs14"><div class="js-top-ranking-score-col di-ib al"><i class="icon-score-star mr4 on"></i><span class="text on">8.70</span></div>
+  </td>
+
+    <td class="your-score ac fs14">
+    <div class="js-top-ranking-your-score-col di-ib al">                                  <a href="https://myanimelist.net/editlist.php?type=anime&amp;id=1535&amp;hideLayout" class="Lightbox_AddEdit"><i class="icon-score-star mr4 on"></i><span class="text on">10</span></a>
+</div>
+  </td>
+
+    <td class="status ac">                                  <a href="https://myanimelist.net/editlist.php?type=anime&amp;id=1535&amp;hideLayout" class="Lightbox_AddEdit btn-addEdit-large btn-anime-watch-status js-anime-watch-status completed">Completed</a>
+</td>
+</tr>
+
+<tr class="ranking-list">
+    <td class="rank ac" valign="top">
+    <span class="lightLink top-anime-rank-text rank1">2</span>
+  </td>
+    <td class="title al va-t word-break">
+    <a class="hoverinfo_trigger fl-l ml12 mr8" href="https://myanimelist.net/anime/16498/Shingeki_no_Kyojin" id="#area16498" rel="#info16498">
+      <img width="50" height="70" alt="Anime: Shingeki no Kyojin" class="lazyload" border="0" data-src="https://myanimelist.cdn-dena.com/r/50x70/images/anime/10/47347.webp?s=6b6f0445f6a93276f3cbd98400582612" data-srcset="https://myanimelist.cdn-dena.com/r/50x70/images/anime/10/47347.webp?s=6b6f0445f6a93276f3cbd98400582612 1x, https://myanimelist.cdn-dena.com/r/100x140/images/anime/10/47347.webp?s=afe8db1357f14bdfdb3d181442e414f4 2x" />
+    </a>
+
+    <div class="detail"><div id="area16498">
+  <div id="info16498" rel="a16498" class="hoverinfo"></div>
+</div>
+<div class="di-ib clearfix"><a class="hoverinfo_trigger fl-l fs14 fw-b" href="https://myanimelist.net/anime/16498/Shingeki_no_Kyojin" id="#area16498" rel="#info16498">Shingeki no Kyojin</a><a href="https://myanimelist.net/anime/16498/Shingeki_no_Kyojin/video" class="icon-watch ml8" title="Watch Episode Video">Watch Episode Video</a></div><br><div class="information di-ib mt4">
+        TV (25 eps)<br>
+        Apr 2013 - Sep 2013<br>
+        982,343 members
+      </div></div>
+  </td>
+
+    <td class="score ac fs14"><div class="js-top-ranking-score-col di-ib al"><i class="icon-score-star mr4 on"></i><span class="text on">8.52</span></div>
+  </td>
+
+    <td class="your-score ac fs14">
+    <div class="js-top-ranking-your-score-col di-ib al">                                  <a href="https://myanimelist.net/editlist.php?type=anime&amp;id=16498&amp;hideLayout" class="Lightbox_AddEdit"><i class="icon-score-star mr4 on"></i><span class="text on">10</span></a>
+</div>
+  </td>
+
+    <td class="status ac">                                  <a href="https://myanimelist.net/editlist.php?type=anime&amp;id=16498&amp;hideLayout" class="Lightbox_AddEdit btn-addEdit-large btn-anime-watch-status js-anime-watch-status completed">Completed</a>
+</td>
+</tr>
+
+<tr class="ranking-list">
+    <td class="rank ac" valign="top">
+    <span class="lightLink top-anime-rank-text rank1">3</span>
+  </td>
+    <td class="title al va-t word-break">
+    <a class="hoverinfo_trigger fl-l ml12 mr8" href="https://myanimelist.net/anime/11757/Sword_Art_Online" id="#area11757" rel="#info11757">
+      <img width="50" height="70" alt="Anime: Sword Art Online" class="lazyload" border="0" data-src="https://myanimelist.cdn-dena.com/r/50x70/images/anime/11/39717.webp?s=144ad61682f5051ec32885d974faeef9" data-srcset="https://myanimelist.cdn-dena.com/r/50x70/images/anime/11/39717.webp?s=144ad61682f5051ec32885d974faeef9 1x, https://myanimelist.cdn-dena.com/r/100x140/images/anime/11/39717.webp?s=34dae4e7cb788b371819d9bb8d445792 2x" />
+    </a>
+
+    <div class="detail"><div id="area11757">
+  <div id="info11757" rel="a11757" class="hoverinfo"></div>
+</div>
+<div class="di-ib clearfix"><a class="hoverinfo_trigger fl-l fs14 fw-b" href="https://myanimelist.net/anime/11757/Sword_Art_Online" id="#area11757" rel="#info11757">Sword Art Online</a><a href="https://myanimelist.net/anime/11757/Sword_Art_Online/video" class="icon-watch ml8" title="Watch Episode Video">Watch Episode Video</a></div><br><div class="information di-ib mt4">
+        TV (25 eps)<br>
+        Jul 2012 - Dec 2012<br>
+        975,675 members
+      </div></div>
+  </td>
+
+    <td class="score ac fs14"><div class="js-top-ranking-score-col di-ib al"><i class="icon-score-star mr4 on"></i><span class="text on">7.78</span></div>
+  </td>
+
+    <td class="your-score ac fs14">
+    <div class="js-top-ranking-your-score-col di-ib al">                                  <a href="https://myanimelist.net/editlist.php?type=anime&amp;id=11757&amp;hideLayout" class="Lightbox_AddEdit"><i class="icon-score-star mr4 on"></i><span class="text on">10</span></a>
+</div>
+  </td>
+
+    <td class="status ac">                                  <a href="https://myanimelist.net/editlist.php?type=anime&amp;id=11757&amp;hideLayout" class="Lightbox_AddEdit btn-addEdit-large btn-anime-watch-status js-anime-watch-status completed">Completed</a>
+</td>
+</tr>
+
+<tr class="ranking-list">
+    <td class="rank ac" valign="top">
+    <span class="lightLink top-anime-rank-text rank1">4</span>
+  </td>
+    <td class="title al va-t word-break">
+    <a class="hoverinfo_trigger fl-l ml12 mr8" href="https://myanimelist.net/anime/5114/Fullmetal_Alchemist__Brotherhood" id="#area5114" rel="#info5114">
+      <img width="50" height="70" alt="Anime: Fullmetal Alchemist: Brotherhood" class="lazyload" border="0" data-src="https://myanimelist.cdn-dena.com/r/50x70/images/anime/5/47421.webp?s=06392961aa190c6c078ea98f60529f11" data-srcset="https://myanimelist.cdn-dena.com/r/50x70/images/anime/5/47421.webp?s=06392961aa190c6c078ea98f60529f11 1x, https://myanimelist.cdn-dena.com/r/100x140/images/anime/5/47421.webp?s=597b2c97f1958da9bf61a1daa9ded156 2x" />
+    </a>
+
+    <div class="detail"><div id="area5114">
+  <div id="info5114" rel="a5114" class="hoverinfo"></div>
+</div>
+<div class="di-ib clearfix"><a class="hoverinfo_trigger fl-l fs14 fw-b" href="https://myanimelist.net/anime/5114/Fullmetal_Alchemist__Brotherhood" id="#area5114" rel="#info5114">Fullmetal Alchemist: Brotherhood</a><a href="https://myanimelist.net/anime/5114/Fullmetal_Alchemist__Brotherhood/video" class="icon-watch ml8" title="Watch Episode Video">Watch Episode Video</a></div><br><div class="information di-ib mt4">
+        TV (64 eps)<br>
+        Apr 2009 - Jul 2010<br>
+        866,078 members
+      </div></div>
+  </td>
+
+    <td class="score ac fs14"><div class="js-top-ranking-score-col di-ib al"><i class="icon-score-star mr4 on"></i><span class="text on">9.26</span></div>
+  </td>
+
+    <td class="your-score ac fs14">
+    <div class="js-top-ranking-your-score-col di-ib al">                                  <a href="https://myanimelist.net/editlist.php?type=anime&amp;id=5114&amp;hideLayout" class="Lightbox_AddEdit"><i class="icon-score-star mr4 "></i><span class="text ">N/A</span></a>
+</div>
+  </td>
+
+    <td class="status ac">                                  <a href="https://myanimelist.net/editlist.php?type=anime&amp;id=5114&amp;hideLayout" class="Lightbox_AddEdit btn-addEdit-large btn-anime-watch-status js-anime-watch-status plantowatch">Plan to Watch</a>
+</td>
+</tr>
+
+<tr class="ranking-list">
+    <td class="rank ac" valign="top">
+    <span class="lightLink top-anime-rank-text rank1">5</span>
+  </td>
+    <td class="title al va-t word-break">
+    <a class="hoverinfo_trigger fl-l ml12 mr8" href="https://myanimelist.net/anime/6547/Angel_Beats" id="#area6547" rel="#info6547">
+      <img width="50" height="70" alt="Anime: Angel Beats!" class="lazyload" border="0" data-src="https://myanimelist.cdn-dena.com/r/50x70/images/anime/10/22061.webp?s=6bf65345c36dfe282aa1655d6ef2f40a" data-srcset="https://myanimelist.cdn-dena.com/r/50x70/images/anime/10/22061.webp?s=6bf65345c36dfe282aa1655d6ef2f40a 1x, https://myanimelist.cdn-dena.com/r/100x140/images/anime/10/22061.webp?s=c9be65b3500283729708e98826b8595f 2x" />
+    </a>
+
+    <div class="detail"><div id="area6547">
+  <div id="info6547" rel="a6547" class="hoverinfo"></div>
+</div>
+<div class="di-ib clearfix"><a class="hoverinfo_trigger fl-l fs14 fw-b" href="https://myanimelist.net/anime/6547/Angel_Beats" id="#area6547" rel="#info6547">Angel Beats!</a><a href="https://myanimelist.net/anime/6547/Angel_Beats/video" class="icon-watch ml8" title="Watch Episode Video">Watch Episode Video</a></div><br><div class="information di-ib mt4">
+        TV (13 eps)<br>
+        Apr 2010 - Jun 2010<br>
+        778,936 members
+      </div></div>
+  </td>
+
+    <td class="score ac fs14"><div class="js-top-ranking-score-col di-ib al"><i class="icon-score-star mr4 on"></i><span class="text on">8.37</span></div>
+  </td>
+
+    <td class="your-score ac fs14">
+    <div class="js-top-ranking-your-score-col di-ib al">                                  <a href="https://myanimelist.net/editlist.php?type=anime&amp;id=6547&amp;hideLayout" class="Lightbox_AddEdit"><i class="icon-score-star mr4 on"></i><span class="text on">10</span></a>
+</div>
+  </td>
+
+    <td class="status ac">                                  <a href="https://myanimelist.net/editlist.php?type=anime&amp;id=6547&amp;hideLayout" class="Lightbox_AddEdit btn-addEdit-large btn-anime-watch-status js-anime-watch-status completed">Completed</a>
+</td>
+</tr>
+
+<tr class="ranking-list">
+    <td class="rank ac" valign="top">
+    <span class="lightLink top-anime-rank-text rank1">6</span>
+  </td>
+    <td class="title al va-t word-break">
+    <a class="hoverinfo_trigger fl-l ml12 mr8" href="https://myanimelist.net/anime/1575/Code_Geass__Hangyaku_no_Lelouch" id="#area1575" rel="#info1575">
+      <img width="50" height="70" alt="Anime: Code Geass: Hangyaku no Lelouch" class="lazyload" border="0" data-src="https://myanimelist.cdn-dena.com/r/50x70/images/anime/5/50331.webp?s=c6edd45e5f04bd2435027b54a9243147" data-srcset="https://myanimelist.cdn-dena.com/r/50x70/images/anime/5/50331.webp?s=c6edd45e5f04bd2435027b54a9243147 1x, https://myanimelist.cdn-dena.com/r/100x140/images/anime/5/50331.webp?s=f3f29eedd7e79c0c43ff1ba8d121fa62 2x" />
+    </a>
+
+    <div class="detail"><div id="area1575">
+  <div id="info1575" rel="a1575" class="hoverinfo"></div>
+</div>
+<div class="di-ib clearfix"><a class="hoverinfo_trigger fl-l fs14 fw-b" href="https://myanimelist.net/anime/1575/Code_Geass__Hangyaku_no_Lelouch" id="#area1575" rel="#info1575">Code Geass: Hangyaku no Lelouch</a><a href="https://myanimelist.net/anime/1575/Code_Geass__Hangyaku_no_Lelouch/video" class="icon-watch-pv ml8" title="Watch Promotional Video">Watch Promotional Video</a></div><br><div class="information di-ib mt4">
+        TV (25 eps)<br>
+        Oct 2006 - Jul 2007<br>
+        769,725 members
+      </div></div>
+  </td>
+
+    <td class="score ac fs14"><div class="js-top-ranking-score-col di-ib al"><i class="icon-score-star mr4 on"></i><span class="text on">8.82</span></div>
+  </td>
+
+    <td class="your-score ac fs14">
+    <div class="js-top-ranking-your-score-col di-ib al">                                  <a href="https://myanimelist.net/editlist.php?type=anime&amp;id=1575&amp;hideLayout" class="Lightbox_AddEdit"><i class="icon-score-star mr4 on"></i><span class="text on">10</span></a>
+</div>
+  </td>
+
+    <td class="status ac">                                  <a href="https://myanimelist.net/editlist.php?type=anime&amp;id=1575&amp;hideLayout" class="Lightbox_AddEdit btn-addEdit-large btn-anime-watch-status js-anime-watch-status completed">Completed</a>
+</td>
+</tr>
+
+<tr class="ranking-list">
+    <td class="rank ac" valign="top">
+    <span class="lightLink top-anime-rank-text rank1">7</span>
+  </td>
+    <td class="title al va-t word-break">
+    <a class="hoverinfo_trigger fl-l ml12 mr8" href="https://myanimelist.net/anime/9253/Steins_Gate" id="#area9253" rel="#info9253">
+      <img width="50" height="70" alt="Anime: Steins;Gate" class="lazyload" border="0" data-src="https://myanimelist.cdn-dena.com/r/50x70/images/anime/5/73199.webp?s=88a9e53d067a524ad1b84e49e13a270a" data-srcset="https://myanimelist.cdn-dena.com/r/50x70/images/anime/5/73199.webp?s=88a9e53d067a524ad1b84e49e13a270a 1x, https://myanimelist.cdn-dena.com/r/100x140/images/anime/5/73199.webp?s=8ee59e1c8ac81eba9d3a883afd73208b 2x" />
+    </a>
+
+    <div class="detail"><div id="area9253">
+  <div id="info9253" rel="a9253" class="hoverinfo"></div>
+</div>
+<div class="di-ib clearfix"><a class="hoverinfo_trigger fl-l fs14 fw-b" href="https://myanimelist.net/anime/9253/Steins_Gate" id="#area9253" rel="#info9253">Steins;Gate</a><a href="https://myanimelist.net/anime/9253/Steins_Gate/video" class="icon-watch-pv ml8" title="Watch Promotional Video">Watch Promotional Video</a></div><br><div class="information di-ib mt4">
+        TV (24 eps)<br>
+        Apr 2011 - Sep 2011<br>
+        738,956 members
+      </div></div>
+  </td>
+
+    <td class="score ac fs14"><div class="js-top-ranking-score-col di-ib al"><i class="icon-score-star mr4 on"></i><span class="text on">9.16</span></div>
+  </td>
+
+    <td class="your-score ac fs14">
+    <div class="js-top-ranking-your-score-col di-ib al">                                  <a href="https://myanimelist.net/editlist.php?type=anime&amp;id=9253&amp;hideLayout" class="Lightbox_AddEdit"><i class="icon-score-star mr4 on"></i><span class="text on">10</span></a>
+</div>
+  </td>
+
+    <td class="status ac">                                  <a href="https://myanimelist.net/editlist.php?type=anime&amp;id=9253&amp;hideLayout" class="Lightbox_AddEdit btn-addEdit-large btn-anime-watch-status js-anime-watch-status completed">Completed</a>
+</td>
+</tr>
+
+<tr class="ranking-list">
+    <td class="rank ac" valign="top">
+    <span class="lightLink top-anime-rank-text rank1">8</span>
+  </td>
+    <td class="title al va-t word-break">
+    <a class="hoverinfo_trigger fl-l ml12 mr8" href="https://myanimelist.net/anime/20/Naruto" id="#area20" rel="#info20">
+      <img width="50" height="70" alt="Anime: Naruto" class="lazyload" border="0" data-src="https://myanimelist.cdn-dena.com/r/50x70/images/anime/13/17405.webp?s=2d3fd489ec5802ca17d315e403dd9dfc" data-srcset="https://myanimelist.cdn-dena.com/r/50x70/images/anime/13/17405.webp?s=2d3fd489ec5802ca17d315e403dd9dfc 1x, https://myanimelist.cdn-dena.com/r/100x140/images/anime/13/17405.webp?s=a2d64a4a519b36a4c03a04f018d13dbf 2x" />
+    </a>
+
+    <div class="detail"><div id="area20">
+  <div id="info20" rel="a20" class="hoverinfo"></div>
+</div>
+<div class="di-ib clearfix"><a class="hoverinfo_trigger fl-l fs14 fw-b" href="https://myanimelist.net/anime/20/Naruto" id="#area20" rel="#info20">Naruto</a><a href="https://myanimelist.net/anime/20/Naruto/video" class="icon-watch ml8" title="Watch Episode Video">Watch Episode Video</a></div><br><div class="information di-ib mt4">
+        TV (220 eps)<br>
+        Oct 2002 - Feb 2007<br>
+        737,778 members
+      </div></div>
+  </td>
+
+    <td class="score ac fs14"><div class="js-top-ranking-score-col di-ib al"><i class="icon-score-star mr4 on"></i><span class="text on">7.82</span></div>
+  </td>
+
+    <td class="your-score ac fs14">
+    <div class="js-top-ranking-your-score-col di-ib al">                        <a href="https://myanimelist.net/panel.php?go=add&amp;selected_series_id=20&amp;hideLayout" class="Lightbox_AddEdit"><i class="icon-score-star mr4 "></i><span class="text ">N/A</span></a>
+</div>
+  </td>
+
+    <td class="status ac">                        <a href="https://myanimelist.net/panel.php?go=add&amp;selected_series_id=20&amp;hideLayout" class="Lightbox_AddEdit btn-addEdit-large btn-anime-watch-status js-anime-watch-status notinmylist"><i class="fa fa-plus-square-o mr4"></i>Add to list</a>
+</td>
+</tr>
+
+<tr class="ranking-list">
+    <td class="rank ac" valign="top">
+    <span class="lightLink top-anime-rank-text rank1">9</span>
+  </td>
+    <td class="title al va-t word-break">
+    <a class="hoverinfo_trigger fl-l ml12 mr8" href="https://myanimelist.net/anime/10620/Mirai_Nikki_TV" id="#area10620" rel="#info10620">
+      <img width="50" height="70" alt="Anime: Mirai Nikki (TV)" class="lazyload" border="0" data-src="https://myanimelist.cdn-dena.com/r/50x70/images/anime/13/33465.webp?s=2c3874d5f8516bcf8a5a528838792fbe" data-srcset="https://myanimelist.cdn-dena.com/r/50x70/images/anime/13/33465.webp?s=2c3874d5f8516bcf8a5a528838792fbe 1x, https://myanimelist.cdn-dena.com/r/100x140/images/anime/13/33465.webp?s=7c3eb86e4bf2239565624456f60443c5 2x" />
+    </a>
+
+    <div class="detail"><div id="area10620">
+  <div id="info10620" rel="a10620" class="hoverinfo"></div>
+</div>
+<div class="di-ib clearfix"><a class="hoverinfo_trigger fl-l fs14 fw-b" href="https://myanimelist.net/anime/10620/Mirai_Nikki_TV" id="#area10620" rel="#info10620">Mirai Nikki (TV)</a><a href="https://myanimelist.net/anime/10620/Mirai_Nikki_TV/video" class="icon-watch-pv ml8" title="Watch Promotional Video">Watch Promotional Video</a></div><br><div class="information di-ib mt4">
+        TV (26 eps)<br>
+        Oct 2011 - Apr 2012<br>
+        721,399 members
+      </div></div>
+  </td>
+
+    <td class="score ac fs14"><div class="js-top-ranking-score-col di-ib al"><i class="icon-score-star mr4 on"></i><span class="text on">8.03</span></div>
+  </td>
+
+    <td class="your-score ac fs14">
+    <div class="js-top-ranking-your-score-col di-ib al">                                  <a href="https://myanimelist.net/editlist.php?type=anime&amp;id=10620&amp;hideLayout" class="Lightbox_AddEdit"><i class="icon-score-star mr4 on"></i><span class="text on">10</span></a>
+</div>
+  </td>
+
+    <td class="status ac">                                  <a href="https://myanimelist.net/editlist.php?type=anime&amp;id=10620&amp;hideLayout" class="Lightbox_AddEdit btn-addEdit-large btn-anime-watch-status js-anime-watch-status completed">Completed</a>
+</td>
+</tr>
+
+<tr class="ranking-list">
+    <td class="rank ac" valign="top">
+    <span class="lightLink top-anime-rank-text rank2">10</span>
+  </td>
+    <td class="title al va-t word-break">
+    <a class="hoverinfo_trigger fl-l ml12 mr8" href="https://myanimelist.net/anime/22319/Tokyo_Ghoul" id="#area22319" rel="#info22319">
+      <img width="50" height="70" alt="Anime: Tokyo Ghoul" class="lazyload" border="0" data-src="https://myanimelist.cdn-dena.com/r/50x70/images/anime/5/64449.webp?s=c78359fd5bb43ff1aa2a17f9446aa2a2" data-srcset="https://myanimelist.cdn-dena.com/r/50x70/images/anime/5/64449.webp?s=c78359fd5bb43ff1aa2a17f9446aa2a2 1x, https://myanimelist.cdn-dena.com/r/100x140/images/anime/5/64449.webp?s=e55243a254260bf7048ac259beb3963a 2x" />
+    </a>
+
+    <div class="detail"><div id="area22319">
+  <div id="info22319" rel="a22319" class="hoverinfo"></div>
+</div>
+<div class="di-ib clearfix"><a class="hoverinfo_trigger fl-l fs14 fw-b" href="https://myanimelist.net/anime/22319/Tokyo_Ghoul" id="#area22319" rel="#info22319">Tokyo Ghoul</a><a href="https://myanimelist.net/anime/22319/Tokyo_Ghoul/video" class="icon-watch-pv ml8" title="Watch Promotional Video">Watch Promotional Video</a></div><br><div class="information di-ib mt4">
+        TV (12 eps)<br>
+        Jul 2014 - Sep 2014<br>
+        695,497 members
+      </div></div>
+  </td>
+
+    <td class="score ac fs14"><div class="js-top-ranking-score-col di-ib al"><i class="icon-score-star mr4 on"></i><span class="text on">8.05</span></div>
+  </td>
+
+    <td class="your-score ac fs14">
+    <div class="js-top-ranking-your-score-col di-ib al">                                  <a href="https://myanimelist.net/editlist.php?type=anime&amp;id=22319&amp;hideLayout" class="Lightbox_AddEdit"><i class="icon-score-star mr4 "></i><span class="text ">N/A</span></a>
+</div>
+  </td>
+
+    <td class="status ac">                                  <a href="https://myanimelist.net/editlist.php?type=anime&amp;id=22319&amp;hideLayout" class="Lightbox_AddEdit btn-addEdit-large btn-anime-watch-status js-anime-watch-status plantowatch">Plan to Watch</a>
+</td>
+</tr>
+
+<tr class="ranking-list">
+    <td class="rank ac" valign="top">
+    <span class="lightLink top-anime-rank-text rank2">11</span>
+  </td>
+    <td class="title al va-t word-break">
+    <a class="hoverinfo_trigger fl-l ml12 mr8" href="https://myanimelist.net/anime/4224/Toradora" id="#area4224" rel="#info4224">
+      <img width="50" height="70" alt="Anime: Toradora!" class="lazyload" border="0" data-src="https://myanimelist.cdn-dena.com/r/50x70/images/anime/13/22128.webp?s=0ff1897e558be0a776061050408411df" data-srcset="https://myanimelist.cdn-dena.com/r/50x70/images/anime/13/22128.webp?s=0ff1897e558be0a776061050408411df 1x, https://myanimelist.cdn-dena.com/r/100x140/images/anime/13/22128.webp?s=7c225c9983d2978f445a58c78fb0220a 2x" />
+    </a>
+
+    <div class="detail"><div id="area4224">
+  <div id="info4224" rel="a4224" class="hoverinfo"></div>
+</div>
+<div class="di-ib clearfix"><a class="hoverinfo_trigger fl-l fs14 fw-b" href="https://myanimelist.net/anime/4224/Toradora" id="#area4224" rel="#info4224">Toradora!</a><a href="https://myanimelist.net/anime/4224/Toradora/video" class="icon-watch ml8" title="Watch Episode Video">Watch Episode Video</a></div><br><div class="information di-ib mt4">
+        TV (25 eps)<br>
+        Oct 2008 - Mar 2009<br>
+        691,717 members
+      </div></div>
+  </td>
+
+    <td class="score ac fs14"><div class="js-top-ranking-score-col di-ib al"><i class="icon-score-star mr4 on"></i><span class="text on">8.44</span></div>
+  </td>
+
+    <td class="your-score ac fs14">
+    <div class="js-top-ranking-your-score-col di-ib al">                                  <a href="https://myanimelist.net/editlist.php?type=anime&amp;id=4224&amp;hideLayout" class="Lightbox_AddEdit"><i class="icon-score-star mr4 on"></i><span class="text on">10</span></a>
+</div>
+  </td>
+
+    <td class="status ac">                                  <a href="https://myanimelist.net/editlist.php?type=anime&amp;id=4224&amp;hideLayout" class="Lightbox_AddEdit btn-addEdit-large btn-anime-watch-status js-anime-watch-status completed">Completed</a>
+</td>
+</tr>
+
+<tr class="ranking-list">
+    <td class="rank ac" valign="top">
+    <span class="lightLink top-anime-rank-text rank2">12</span>
+  </td>
+    <td class="title al va-t word-break">
+    <a class="hoverinfo_trigger fl-l ml12 mr8" href="https://myanimelist.net/anime/19815/No_Game_No_Life" id="#area19815" rel="#info19815">
+      <img width="50" height="70" alt="Anime: No Game No Life" class="lazyload" border="0" data-src="https://myanimelist.cdn-dena.com/r/50x70/images/anime/5/65187.webp?s=fd1048e7e02d97f7183eb7c5f0c39e70" data-srcset="https://myanimelist.cdn-dena.com/r/50x70/images/anime/5/65187.webp?s=fd1048e7e02d97f7183eb7c5f0c39e70 1x, https://myanimelist.cdn-dena.com/r/100x140/images/anime/5/65187.webp?s=346be8c82188f9aea5d580d3a299d9cd 2x" />
+    </a>
+
+    <div class="detail"><div id="area19815">
+  <div id="info19815" rel="a19815" class="hoverinfo"></div>
+</div>
+<div class="di-ib clearfix"><a class="hoverinfo_trigger fl-l fs14 fw-b" href="https://myanimelist.net/anime/19815/No_Game_No_Life" id="#area19815" rel="#info19815">No Game No Life</a><a href="https://myanimelist.net/anime/19815/No_Game_No_Life/video" class="icon-watch ml8" title="Watch Episode Video">Watch Episode Video</a></div><br><div class="information di-ib mt4">
+        TV (12 eps)<br>
+        Apr 2014 - Jun 2014<br>
+        675,622 members
+      </div></div>
+  </td>
+
+    <td class="score ac fs14"><div class="js-top-ranking-score-col di-ib al"><i class="icon-score-star mr4 on"></i><span class="text on">8.45</span></div>
+  </td>
+
+    <td class="your-score ac fs14">
+    <div class="js-top-ranking-your-score-col di-ib al">                                  <a href="https://myanimelist.net/editlist.php?type=anime&amp;id=19815&amp;hideLayout" class="Lightbox_AddEdit"><i class="icon-score-star mr4 on"></i><span class="text on">10</span></a>
+</div>
+  </td>
+
+    <td class="status ac">                                  <a href="https://myanimelist.net/editlist.php?type=anime&amp;id=19815&amp;hideLayout" class="Lightbox_AddEdit btn-addEdit-large btn-anime-watch-status js-anime-watch-status completed">Completed</a>
+</td>
+</tr>
+
+<tr class="ranking-list">
+    <td class="rank ac" valign="top">
+    <span class="lightLink top-anime-rank-text rank2">13</span>
+  </td>
+    <td class="title al va-t word-break">
+    <a class="hoverinfo_trigger fl-l ml12 mr8" href="https://myanimelist.net/anime/226/Elfen_Lied" id="#area226" rel="#info226">
+      <img width="50" height="70" alt="Anime: Elfen Lied" class="lazyload" border="0" data-src="https://myanimelist.cdn-dena.com/r/50x70/images/anime/10/6883.webp?s=36c3c91683e6e19bef9ef4a115e7a09c" data-srcset="https://myanimelist.cdn-dena.com/r/50x70/images/anime/10/6883.webp?s=36c3c91683e6e19bef9ef4a115e7a09c 1x, https://myanimelist.cdn-dena.com/r/100x140/images/anime/10/6883.webp?s=35b95dcebcd857b76caaf4d477b75e7e 2x" />
+    </a>
+
+    <div class="detail"><div id="area226">
+  <div id="info226" rel="a226" class="hoverinfo"></div>
+</div>
+<div class="di-ib clearfix"><a class="hoverinfo_trigger fl-l fs14 fw-b" href="https://myanimelist.net/anime/226/Elfen_Lied" id="#area226" rel="#info226">Elfen Lied</a><a href="https://myanimelist.net/anime/226/Elfen_Lied/video" class="icon-watch ml8" title="Watch Episode Video">Watch Episode Video</a></div><br><div class="information di-ib mt4">
+        TV (13 eps)<br>
+        Jul 2004 - Oct 2004<br>
+        667,938 members
+      </div></div>
+  </td>
+
+    <td class="score ac fs14"><div class="js-top-ranking-score-col di-ib al"><i class="icon-score-star mr4 on"></i><span class="text on">7.83</span></div>
+  </td>
+
+    <td class="your-score ac fs14">
+    <div class="js-top-ranking-your-score-col di-ib al">                                  <a href="https://myanimelist.net/editlist.php?type=anime&amp;id=226&amp;hideLayout" class="Lightbox_AddEdit"><i class="icon-score-star mr4 on"></i><span class="text on">9</span></a>
+</div>
+  </td>
+
+    <td class="status ac">                                  <a href="https://myanimelist.net/editlist.php?type=anime&amp;id=226&amp;hideLayout" class="Lightbox_AddEdit btn-addEdit-large btn-anime-watch-status js-anime-watch-status completed">Completed</a>
+</td>
+</tr>
+
+<tr class="ranking-list">
+    <td class="rank ac" valign="top">
+    <span class="lightLink top-anime-rank-text rank2">14</span>
+  </td>
+    <td class="title al va-t word-break">
+    <a class="hoverinfo_trigger fl-l ml12 mr8" href="https://myanimelist.net/anime/269/Bleach" id="#area269" rel="#info269">
+      <img width="50" height="70" alt="Anime: Bleach" class="lazyload" border="0" data-src="https://myanimelist.cdn-dena.com/r/50x70/images/anime/3/40451.webp?s=ed8a04b64c3ec4c26d38d62e994b4625" data-srcset="https://myanimelist.cdn-dena.com/r/50x70/images/anime/3/40451.webp?s=ed8a04b64c3ec4c26d38d62e994b4625 1x, https://myanimelist.cdn-dena.com/r/100x140/images/anime/3/40451.webp?s=442f274dd5c200ff2f7c24bdf511a37b 2x" />
+    </a>
+
+    <div class="detail"><div id="area269">
+  <div id="info269" rel="a269" class="hoverinfo"></div>
+</div>
+<div class="di-ib clearfix"><a class="hoverinfo_trigger fl-l fs14 fw-b" href="https://myanimelist.net/anime/269/Bleach" id="#area269" rel="#info269">Bleach</a><a href="https://myanimelist.net/anime/269/Bleach/video" class="icon-watch ml8" title="Watch Episode Video">Watch Episode Video</a></div><br><div class="information di-ib mt4">
+        TV (366 eps)<br>
+        Oct 2004 - Mar 2012<br>
+        662,614 members
+      </div></div>
+  </td>
+
+    <td class="score ac fs14"><div class="js-top-ranking-score-col di-ib al"><i class="icon-score-star mr4 on"></i><span class="text on">7.94</span></div>
+  </td>
+
+    <td class="your-score ac fs14">
+    <div class="js-top-ranking-your-score-col di-ib al">                        <a href="https://myanimelist.net/panel.php?go=add&amp;selected_series_id=269&amp;hideLayout" class="Lightbox_AddEdit"><i class="icon-score-star mr4 "></i><span class="text ">N/A</span></a>
+</div>
+  </td>
+
+    <td class="status ac">                        <a href="https://myanimelist.net/panel.php?go=add&amp;selected_series_id=269&amp;hideLayout" class="Lightbox_AddEdit btn-addEdit-large btn-anime-watch-status js-anime-watch-status notinmylist"><i class="fa fa-plus-square-o mr4"></i>Add to list</a>
+</td>
+</tr>
+
+<tr class="ranking-list">
+    <td class="rank ac" valign="top">
+    <span class="lightLink top-anime-rank-text rank2">15</span>
+  </td>
+    <td class="title al va-t word-break">
+    <a class="hoverinfo_trigger fl-l ml12 mr8" href="https://myanimelist.net/anime/9919/Ao_no_Exorcist" id="#area9919" rel="#info9919">
+      <img width="50" height="70" alt="Anime: Ao no Exorcist" class="lazyload" border="0" data-src="https://myanimelist.cdn-dena.com/r/50x70/images/anime/10/75195.webp?s=cbf3ece579cb715b5105221a7e7a1124" data-srcset="https://myanimelist.cdn-dena.com/r/50x70/images/anime/10/75195.webp?s=cbf3ece579cb715b5105221a7e7a1124 1x, https://myanimelist.cdn-dena.com/r/100x140/images/anime/10/75195.webp?s=252e11c5044d7ee1cc90255157e944ac 2x" />
+    </a>
+
+    <div class="detail"><div id="area9919">
+  <div id="info9919" rel="a9919" class="hoverinfo"></div>
+</div>
+<div class="di-ib clearfix"><a class="hoverinfo_trigger fl-l fs14 fw-b" href="https://myanimelist.net/anime/9919/Ao_no_Exorcist" id="#area9919" rel="#info9919">Ao no Exorcist</a><a href="https://myanimelist.net/anime/9919/Ao_no_Exorcist/video" class="icon-watch ml8" title="Watch Episode Video">Watch Episode Video</a></div><br><div class="information di-ib mt4">
+        TV (25 eps)<br>
+        Apr 2011 - Oct 2011<br>
+        649,829 members
+      </div></div>
+  </td>
+
+    <td class="score ac fs14"><div class="js-top-ranking-score-col di-ib al"><i class="icon-score-star mr4 on"></i><span class="text on">7.91</span></div>
+  </td>
+
+    <td class="your-score ac fs14">
+    <div class="js-top-ranking-your-score-col di-ib al">                                  <a href="https://myanimelist.net/editlist.php?type=anime&amp;id=9919&amp;hideLayout" class="Lightbox_AddEdit"><i class="icon-score-star mr4 "></i><span class="text ">N/A</span></a>
+</div>
+  </td>
+
+    <td class="status ac">                                  <a href="https://myanimelist.net/editlist.php?type=anime&amp;id=9919&amp;hideLayout" class="Lightbox_AddEdit btn-addEdit-large btn-anime-watch-status js-anime-watch-status plantowatch">Plan to Watch</a>
+</td>
+</tr>
+
+<tr class="ranking-list">
+    <td class="rank ac" valign="top">
+    <span class="lightLink top-anime-rank-text rank2">16</span>
+  </td>
+    <td class="title al va-t word-break">
+    <a class="hoverinfo_trigger fl-l ml12 mr8" href="https://myanimelist.net/anime/30276/One_Punch_Man" id="#area30276" rel="#info30276">
+      <img width="50" height="70" alt="Anime: One Punch Man" class="lazyload" border="0" data-src="https://myanimelist.cdn-dena.com/r/50x70/images/anime/12/76049.webp?s=d3b915e5ccf3e9462a9452fbb37b50b1" data-srcset="https://myanimelist.cdn-dena.com/r/50x70/images/anime/12/76049.webp?s=d3b915e5ccf3e9462a9452fbb37b50b1 1x, https://myanimelist.cdn-dena.com/r/100x140/images/anime/12/76049.webp?s=66e84e9c67e2a263412967676a7bf22f 2x" />
+    </a>
+
+    <div class="detail"><div id="area30276">
+  <div id="info30276" rel="a30276" class="hoverinfo"></div>
+</div>
+<div class="di-ib clearfix"><a class="hoverinfo_trigger fl-l fs14 fw-b" href="https://myanimelist.net/anime/30276/One_Punch_Man" id="#area30276" rel="#info30276">One Punch Man</a><a href="https://myanimelist.net/anime/30276/One_Punch_Man/video" class="icon-watch ml8" title="Watch Episode Video">Watch Episode Video</a></div><br><div class="information di-ib mt4">
+        TV (12 eps)<br>
+        Oct 2015 - Dec 2015<br>
+        642,470 members
+      </div></div>
+  </td>
+
+    <td class="score ac fs14"><div class="js-top-ranking-score-col di-ib al"><i class="icon-score-star mr4 on"></i><span class="text on">8.79</span></div>
+  </td>
+
+    <td class="your-score ac fs14">
+    <div class="js-top-ranking-your-score-col di-ib al">                                  <a href="https://myanimelist.net/editlist.php?type=anime&amp;id=30276&amp;hideLayout" class="Lightbox_AddEdit"><i class="icon-score-star mr4 on"></i><span class="text on">10</span></a>
+</div>
+  </td>
+
+    <td class="status ac">                                  <a href="https://myanimelist.net/editlist.php?type=anime&amp;id=30276&amp;hideLayout" class="Lightbox_AddEdit btn-addEdit-large btn-anime-watch-status js-anime-watch-status completed">Completed</a>
+</td>
+</tr>
+
+<tr class="ranking-list">
+    <td class="rank ac" valign="top">
+    <span class="lightLink top-anime-rank-text rank2">17</span>
+  </td>
+    <td class="title al va-t word-break">
+    <a class="hoverinfo_trigger fl-l ml12 mr8" href="https://myanimelist.net/anime/121/Fullmetal_Alchemist" id="#area121" rel="#info121">
+      <img width="50" height="70" alt="Anime: Fullmetal Alchemist" class="lazyload" border="0" data-src="https://myanimelist.cdn-dena.com/r/50x70/images/anime/10/75815.webp?s=14768f109a5a5f8e87a4ea03d6f00853" data-srcset="https://myanimelist.cdn-dena.com/r/50x70/images/anime/10/75815.webp?s=14768f109a5a5f8e87a4ea03d6f00853 1x, https://myanimelist.cdn-dena.com/r/100x140/images/anime/10/75815.webp?s=c1cbaf52ba1fdd860db074349085a63a 2x" />
+    </a>
+
+    <div class="detail"><div id="area121">
+  <div id="info121" rel="a121" class="hoverinfo"></div>
+</div>
+<div class="di-ib clearfix"><a class="hoverinfo_trigger fl-l fs14 fw-b" href="https://myanimelist.net/anime/121/Fullmetal_Alchemist" id="#area121" rel="#info121">Fullmetal Alchemist</a><a href="https://myanimelist.net/anime/121/Fullmetal_Alchemist/video" class="icon-watch-pv ml8" title="Watch Promotional Video">Watch Promotional Video</a></div><br><div class="information di-ib mt4">
+        TV (51 eps)<br>
+        Oct 2003 - Oct 2004<br>
+        638,867 members
+      </div></div>
+  </td>
+
+    <td class="score ac fs14"><div class="js-top-ranking-score-col di-ib al"><i class="icon-score-star mr4 on"></i><span class="text on">8.32</span></div>
+  </td>
+
+    <td class="your-score ac fs14">
+    <div class="js-top-ranking-your-score-col di-ib al">                        <a href="https://myanimelist.net/panel.php?go=add&amp;selected_series_id=121&amp;hideLayout" class="Lightbox_AddEdit"><i class="icon-score-star mr4 "></i><span class="text ">N/A</span></a>
+</div>
+  </td>
+
+    <td class="status ac">                        <a href="https://myanimelist.net/panel.php?go=add&amp;selected_series_id=121&amp;hideLayout" class="Lightbox_AddEdit btn-addEdit-large btn-anime-watch-status js-anime-watch-status notinmylist"><i class="fa fa-plus-square-o mr4"></i>Add to list</a>
+</td>
+</tr>
+
+<tr class="ranking-list">
+    <td class="rank ac" valign="top">
+    <span class="lightLink top-anime-rank-text rank2">18</span>
+  </td>
+    <td class="title al va-t word-break">
+    <a class="hoverinfo_trigger fl-l ml12 mr8" href="https://myanimelist.net/anime/6702/Fairy_Tail" id="#area6702" rel="#info6702">
+      <img width="50" height="70" alt="Anime: Fairy Tail" class="lazyload" border="0" data-src="https://myanimelist.cdn-dena.com/r/50x70/images/anime/5/18179.webp?s=42f602c4cf49887dd3f304805362c112" data-srcset="https://myanimelist.cdn-dena.com/r/50x70/images/anime/5/18179.webp?s=42f602c4cf49887dd3f304805362c112 1x, https://myanimelist.cdn-dena.com/r/100x140/images/anime/5/18179.webp?s=5fc65e46174d1610e021807721030dd5 2x" />
+    </a>
+
+    <div class="detail"><div id="area6702">
+  <div id="info6702" rel="a6702" class="hoverinfo"></div>
+</div>
+<div class="di-ib clearfix"><a class="hoverinfo_trigger fl-l fs14 fw-b" href="https://myanimelist.net/anime/6702/Fairy_Tail" id="#area6702" rel="#info6702">Fairy Tail</a><a href="https://myanimelist.net/anime/6702/Fairy_Tail/video" class="icon-watch ml8" title="Watch Episode Video">Watch Episode Video</a></div><br><div class="information di-ib mt4">
+        TV (175 eps)<br>
+        Oct 2009 - Mar 2013<br>
+        631,173 members
+      </div></div>
+  </td>
+
+    <td class="score ac fs14"><div class="js-top-ranking-score-col di-ib al"><i class="icon-score-star mr4 on"></i><span class="text on">8.20</span></div>
+  </td>
+
+    <td class="your-score ac fs14">
+    <div class="js-top-ranking-your-score-col di-ib al">                                  <a href="https://myanimelist.net/editlist.php?type=anime&amp;id=6702&amp;hideLayout" class="Lightbox_AddEdit"><i class="icon-score-star mr4 "></i><span class="text ">N/A</span></a>
+</div>
+  </td>
+
+    <td class="status ac">                                  <a href="https://myanimelist.net/editlist.php?type=anime&amp;id=6702&amp;hideLayout" class="Lightbox_AddEdit btn-addEdit-large btn-anime-watch-status js-anime-watch-status plantowatch">Plan to Watch</a>
+</td>
+</tr>
+
+<tr class="ranking-list">
+    <td class="rank ac" valign="top">
+    <span class="lightLink top-anime-rank-text rank2">19</span>
+  </td>
+    <td class="title al va-t word-break">
+    <a class="hoverinfo_trigger fl-l ml12 mr8" href="https://myanimelist.net/anime/3588/Soul_Eater" id="#area3588" rel="#info3588">
+      <img width="50" height="70" alt="Anime: Soul Eater" class="lazyload" border="0" data-src="https://myanimelist.cdn-dena.com/r/50x70/images/anime/9/7804.webp?s=870b75be4724faadcd28092f95482245" data-srcset="https://myanimelist.cdn-dena.com/r/50x70/images/anime/9/7804.webp?s=870b75be4724faadcd28092f95482245 1x, https://myanimelist.cdn-dena.com/r/100x140/images/anime/9/7804.webp?s=74a489fe0d0411e2ade6dc006e4bd4bc 2x" />
+    </a>
+
+    <div class="detail"><div id="area3588">
+  <div id="info3588" rel="a3588" class="hoverinfo"></div>
+</div>
+<div class="di-ib clearfix"><a class="hoverinfo_trigger fl-l fs14 fw-b" href="https://myanimelist.net/anime/3588/Soul_Eater" id="#area3588" rel="#info3588">Soul Eater</a><a href="https://myanimelist.net/anime/3588/Soul_Eater/video" class="icon-watch-pv ml8" title="Watch Promotional Video">Watch Promotional Video</a></div><br><div class="information di-ib mt4">
+        TV (51 eps)<br>
+        Apr 2008 - Mar 2009<br>
+        622,834 members
+      </div></div>
+  </td>
+
+    <td class="score ac fs14"><div class="js-top-ranking-score-col di-ib al"><i class="icon-score-star mr4 on"></i><span class="text on">8.07</span></div>
+  </td>
+
+    <td class="your-score ac fs14">
+    <div class="js-top-ranking-your-score-col di-ib al">                                  <a href="https://myanimelist.net/editlist.php?type=anime&amp;id=3588&amp;hideLayout" class="Lightbox_AddEdit"><i class="icon-score-star mr4 "></i><span class="text ">N/A</span></a>
+</div>
+  </td>
+
+    <td class="status ac">                                  <a href="https://myanimelist.net/editlist.php?type=anime&amp;id=3588&amp;hideLayout" class="Lightbox_AddEdit btn-addEdit-large btn-anime-watch-status js-anime-watch-status plantowatch">Plan to Watch</a>
+</td>
+</tr>
+
+<tr class="ranking-list">
+    <td class="rank ac" valign="top">
+    <span class="lightLink top-anime-rank-text rank2">20</span>
+  </td>
+    <td class="title al va-t word-break">
+    <a class="hoverinfo_trigger fl-l ml12 mr8" href="https://myanimelist.net/anime/2904/Code_Geass__Hangyaku_no_Lelouch_R2" id="#area2904" rel="#info2904">
+      <img width="50" height="70" alt="Anime: Code Geass: Hangyaku no Lelouch R2" class="lazyload" border="0" data-src="https://myanimelist.cdn-dena.com/r/50x70/images/anime/4/9391.webp?s=dfbaf68056de8f6a5612cdbda22cf848" data-srcset="https://myanimelist.cdn-dena.com/r/50x70/images/anime/4/9391.webp?s=dfbaf68056de8f6a5612cdbda22cf848 1x, https://myanimelist.cdn-dena.com/r/100x140/images/anime/4/9391.webp?s=edcaebded20fefe08e46eb2ff87cba7a 2x" />
+    </a>
+
+    <div class="detail"><div id="area2904">
+  <div id="info2904" rel="a2904" class="hoverinfo"></div>
+</div>
+<div class="di-ib clearfix"><a class="hoverinfo_trigger fl-l fs14 fw-b" href="https://myanimelist.net/anime/2904/Code_Geass__Hangyaku_no_Lelouch_R2" id="#area2904" rel="#info2904">Code Geass: Hangyaku no Lelouch R2</a><a href="https://myanimelist.net/anime/2904/Code_Geass__Hangyaku_no_Lelouch_R2/video" class="icon-watch-pv ml8" title="Watch Promotional Video">Watch Promotional Video</a></div><br><div class="information di-ib mt4">
+        TV (25 eps)<br>
+        Apr 2008 - Sep 2008<br>
+        616,873 members
+      </div></div>
+  </td>
+
+    <td class="score ac fs14"><div class="js-top-ranking-score-col di-ib al"><i class="icon-score-star mr4 on"></i><span class="text on">8.97</span></div>
+  </td>
+
+    <td class="your-score ac fs14">
+    <div class="js-top-ranking-your-score-col di-ib al">                                  <a href="https://myanimelist.net/editlist.php?type=anime&amp;id=2904&amp;hideLayout" class="Lightbox_AddEdit"><i class="icon-score-star mr4 on"></i><span class="text on">10</span></a>
+</div>
+  </td>
+
+    <td class="status ac">                                  <a href="https://myanimelist.net/editlist.php?type=anime&amp;id=2904&amp;hideLayout" class="Lightbox_AddEdit btn-addEdit-large btn-anime-watch-status js-anime-watch-status completed">Completed</a>
+</td>
+</tr>
+
+<tr class="ranking-list">
+    <td class="rank ac" valign="top">
+    <span class="lightLink top-anime-rank-text rank2">21</span>
+  </td>
+    <td class="title al va-t word-break">
+    <a class="hoverinfo_trigger fl-l ml12 mr8" href="https://myanimelist.net/anime/2001/Tengen_Toppa_Gurren_Lagann" id="#area2001" rel="#info2001">
+      <img width="50" height="70" alt="Anime: Tengen Toppa Gurren Lagann" class="lazyload" border="0" data-src="https://myanimelist.cdn-dena.com/r/50x70/images/anime/4/5123.webp?s=c34cacc696bd3dff67177eda401e75fb" data-srcset="https://myanimelist.cdn-dena.com/r/50x70/images/anime/4/5123.webp?s=c34cacc696bd3dff67177eda401e75fb 1x, https://myanimelist.cdn-dena.com/r/100x140/images/anime/4/5123.webp?s=8d2d2c3ba063a724a7f16d9ad891b6fd 2x" />
+    </a>
+
+    <div class="detail"><div id="area2001">
+  <div id="info2001" rel="a2001" class="hoverinfo"></div>
+</div>
+<div class="di-ib clearfix"><a class="hoverinfo_trigger fl-l fs14 fw-b" href="https://myanimelist.net/anime/2001/Tengen_Toppa_Gurren_Lagann" id="#area2001" rel="#info2001">Tengen Toppa Gurren Lagann</a><a href="https://myanimelist.net/anime/2001/Tengen_Toppa_Gurren_Lagann/video" class="icon-watch ml8" title="Watch Episode Video">Watch Episode Video</a></div><br><div class="information di-ib mt4">
+        TV (27 eps)<br>
+        Apr 2007 - Sep 2007<br>
+        606,102 members
+      </div></div>
+  </td>
+
+    <td class="score ac fs14"><div class="js-top-ranking-score-col di-ib al"><i class="icon-score-star mr4 on"></i><span class="text on">8.77</span></div>
+  </td>
+
+    <td class="your-score ac fs14">
+    <div class="js-top-ranking-your-score-col di-ib al">                                  <a href="https://myanimelist.net/editlist.php?type=anime&amp;id=2001&amp;hideLayout" class="Lightbox_AddEdit"><i class="icon-score-star mr4 on"></i><span class="text on">10</span></a>
+</div>
+  </td>
+
+    <td class="status ac">                                  <a href="https://myanimelist.net/editlist.php?type=anime&amp;id=2001&amp;hideLayout" class="Lightbox_AddEdit btn-addEdit-large btn-anime-watch-status js-anime-watch-status completed">Completed</a>
+</td>
+</tr>
+
+<tr class="ranking-list">
+    <td class="rank ac" valign="top">
+    <span class="lightLink top-anime-rank-text rank2">22</span>
+  </td>
+    <td class="title al va-t word-break">
+    <a class="hoverinfo_trigger fl-l ml12 mr8" href="https://myanimelist.net/anime/2167/Clannad" id="#area2167" rel="#info2167">
+      <img width="50" height="70" alt="Anime: Clannad" class="lazyload" border="0" data-src="https://myanimelist.cdn-dena.com/r/50x70/images/anime/13/8498.webp?s=af68808d8322e6c2b1de4d0acc092ad8" data-srcset="https://myanimelist.cdn-dena.com/r/50x70/images/anime/13/8498.webp?s=af68808d8322e6c2b1de4d0acc092ad8 1x, https://myanimelist.cdn-dena.com/r/100x140/images/anime/13/8498.webp?s=2f24dc72ceab7b9c8072314a9da3e33b 2x" />
+    </a>
+
+    <div class="detail"><div id="area2167">
+  <div id="info2167" rel="a2167" class="hoverinfo"></div>
+</div>
+<div class="di-ib clearfix"><a class="hoverinfo_trigger fl-l fs14 fw-b" href="https://myanimelist.net/anime/2167/Clannad" id="#area2167" rel="#info2167">Clannad</a><a href="https://myanimelist.net/anime/2167/Clannad/video" class="icon-watch ml8" title="Watch Episode Video">Watch Episode Video</a></div><br><div class="information di-ib mt4">
+        TV (23 eps)<br>
+        Oct 2007 - Mar 2008<br>
+        603,174 members
+      </div></div>
+  </td>
+
+    <td class="score ac fs14"><div class="js-top-ranking-score-col di-ib al"><i class="icon-score-star mr4 on"></i><span class="text on">8.28</span></div>
+  </td>
+
+    <td class="your-score ac fs14">
+    <div class="js-top-ranking-your-score-col di-ib al">                                  <a href="https://myanimelist.net/editlist.php?type=anime&amp;id=2167&amp;hideLayout" class="Lightbox_AddEdit"><i class="icon-score-star mr4 on"></i><span class="text on">10</span></a>
+</div>
+  </td>
+
+    <td class="status ac">                                  <a href="https://myanimelist.net/editlist.php?type=anime&amp;id=2167&amp;hideLayout" class="Lightbox_AddEdit btn-addEdit-large btn-anime-watch-status js-anime-watch-status completed">Completed</a>
+</td>
+</tr>
+
+<tr class="ranking-list">
+    <td class="rank ac" valign="top">
+    <span class="lightLink top-anime-rank-text rank2">23</span>
+  </td>
+    <td class="title al va-t word-break">
+    <a class="hoverinfo_trigger fl-l ml12 mr8" href="https://myanimelist.net/anime/21881/Sword_Art_Online_II" id="#area21881" rel="#info21881">
+      <img width="50" height="70" alt="Anime: Sword Art Online II" class="lazyload" border="0" data-src="https://myanimelist.cdn-dena.com/r/50x70/images/anime/11/65185.webp?s=0801ccb000b8623f0a4bee2fd3cb4c5d" data-srcset="https://myanimelist.cdn-dena.com/r/50x70/images/anime/11/65185.webp?s=0801ccb000b8623f0a4bee2fd3cb4c5d 1x, https://myanimelist.cdn-dena.com/r/100x140/images/anime/11/65185.webp?s=0bd894af8dd9f5f6d7e02e4b7b079764 2x" />
+    </a>
+
+    <div class="detail"><div id="area21881">
+  <div id="info21881" rel="a21881" class="hoverinfo"></div>
+</div>
+<div class="di-ib clearfix"><a class="hoverinfo_trigger fl-l fs14 fw-b" href="https://myanimelist.net/anime/21881/Sword_Art_Online_II" id="#area21881" rel="#info21881">Sword Art Online II</a><a href="https://myanimelist.net/anime/21881/Sword_Art_Online_II/video" class="icon-watch ml8" title="Watch Episode Video">Watch Episode Video</a></div><br><div class="information di-ib mt4">
+        TV (24 eps)<br>
+        Jul 2014 - Dec 2014<br>
+        598,845 members
+      </div></div>
+  </td>
+
+    <td class="score ac fs14"><div class="js-top-ranking-score-col di-ib al"><i class="icon-score-star mr4 on"></i><span class="text on">7.31</span></div>
+  </td>
+
+    <td class="your-score ac fs14">
+    <div class="js-top-ranking-your-score-col di-ib al">                                  <a href="https://myanimelist.net/editlist.php?type=anime&amp;id=21881&amp;hideLayout" class="Lightbox_AddEdit"><i class="icon-score-star mr4 on"></i><span class="text on">10</span></a>
+</div>
+  </td>
+
+    <td class="status ac">                                  <a href="https://myanimelist.net/editlist.php?type=anime&amp;id=21881&amp;hideLayout" class="Lightbox_AddEdit btn-addEdit-large btn-anime-watch-status js-anime-watch-status completed">Completed</a>
+</td>
+</tr>
+
+<tr class="ranking-list">
+    <td class="rank ac" valign="top">
+    <span class="lightLink top-anime-rank-text rank2">24</span>
+  </td>
+    <td class="title al va-t word-break">
+    <a class="hoverinfo_trigger fl-l ml12 mr8" href="https://myanimelist.net/anime/6746/Durarara" id="#area6746" rel="#info6746">
+      <img width="50" height="70" alt="Anime: Durarara!!" class="lazyload" border="0" data-src="https://myanimelist.cdn-dena.com/r/50x70/images/anime/10/71772.webp?s=78267336dc1cf2f57e600dcf9a4251cc" data-srcset="https://myanimelist.cdn-dena.com/r/50x70/images/anime/10/71772.webp?s=78267336dc1cf2f57e600dcf9a4251cc 1x, https://myanimelist.cdn-dena.com/r/100x140/images/anime/10/71772.webp?s=364c748a93e753ecf2998df6b7e3b247 2x" />
+    </a>
+
+    <div class="detail"><div id="area6746">
+  <div id="info6746" rel="a6746" class="hoverinfo"></div>
+</div>
+<div class="di-ib clearfix"><a class="hoverinfo_trigger fl-l fs14 fw-b" href="https://myanimelist.net/anime/6746/Durarara" id="#area6746" rel="#info6746">Durarara!!</a><a href="https://myanimelist.net/anime/6746/Durarara/video" class="icon-watch ml8" title="Watch Episode Video">Watch Episode Video</a></div><br><div class="information di-ib mt4">
+        TV (24 eps)<br>
+        Jan 2010 - Jun 2010<br>
+        596,994 members
+      </div></div>
+  </td>
+
+    <td class="score ac fs14"><div class="js-top-ranking-score-col di-ib al"><i class="icon-score-star mr4 on"></i><span class="text on">8.36</span></div>
+  </td>
+
+    <td class="your-score ac fs14">
+    <div class="js-top-ranking-your-score-col di-ib al">                        <a href="https://myanimelist.net/panel.php?go=add&amp;selected_series_id=6746&amp;hideLayout" class="Lightbox_AddEdit"><i class="icon-score-star mr4 "></i><span class="text ">N/A</span></a>
+</div>
+  </td>
+
+    <td class="status ac">                        <a href="https://myanimelist.net/panel.php?go=add&amp;selected_series_id=6746&amp;hideLayout" class="Lightbox_AddEdit btn-addEdit-large btn-anime-watch-status js-anime-watch-status notinmylist"><i class="fa fa-plus-square-o mr4"></i>Add to list</a>
+</td>
+</tr>
+
+<tr class="ranking-list">
+    <td class="rank ac" valign="top">
+    <span class="lightLink top-anime-rank-text rank2">25</span>
+  </td>
+    <td class="title al va-t word-break">
+    <a class="hoverinfo_trigger fl-l ml12 mr8" href="https://myanimelist.net/anime/11111/Another" id="#area11111" rel="#info11111">
+      <img width="50" height="70" alt="Anime: Another" class="lazyload" border="0" data-src="https://myanimelist.cdn-dena.com/r/50x70/images/anime/4/75509.webp?s=bc980520badc59c475a7633e140735f1" data-srcset="https://myanimelist.cdn-dena.com/r/50x70/images/anime/4/75509.webp?s=bc980520badc59c475a7633e140735f1 1x, https://myanimelist.cdn-dena.com/r/100x140/images/anime/4/75509.webp?s=679e4e9b9709f4c2782152ba8bcac221 2x" />
+    </a>
+
+    <div class="detail"><div id="area11111">
+  <div id="info11111" rel="a11111" class="hoverinfo"></div>
+</div>
+<div class="di-ib clearfix"><a class="hoverinfo_trigger fl-l fs14 fw-b" href="https://myanimelist.net/anime/11111/Another" id="#area11111" rel="#info11111">Another</a><a href="https://myanimelist.net/anime/11111/Another/video" class="icon-watch ml8" title="Watch Episode Video">Watch Episode Video</a></div><br><div class="information di-ib mt4">
+        TV (12 eps)<br>
+        Jan 2012 - Mar 2012<br>
+        584,776 members
+      </div></div>
+  </td>
+
+    <td class="score ac fs14"><div class="js-top-ranking-score-col di-ib al"><i class="icon-score-star mr4 on"></i><span class="text on">7.86</span></div>
+  </td>
+
+    <td class="your-score ac fs14">
+    <div class="js-top-ranking-your-score-col di-ib al">                        <a href="https://myanimelist.net/panel.php?go=add&amp;selected_series_id=11111&amp;hideLayout" class="Lightbox_AddEdit"><i class="icon-score-star mr4 "></i><span class="text ">N/A</span></a>
+</div>
+  </td>
+
+    <td class="status ac">                        <a href="https://myanimelist.net/panel.php?go=add&amp;selected_series_id=11111&amp;hideLayout" class="Lightbox_AddEdit btn-addEdit-large btn-anime-watch-status js-anime-watch-status notinmylist"><i class="fa fa-plus-square-o mr4"></i>Add to list</a>
+</td>
+</tr>
+
+<tr class="ranking-list">
+    <td class="rank ac" valign="top">
+    <span class="lightLink top-anime-rank-text rank2">26</span>
+  </td>
+    <td class="title al va-t word-break">
+    <a class="hoverinfo_trigger fl-l ml12 mr8" href="https://myanimelist.net/anime/20507/Noragami" id="#area20507" rel="#info20507">
+      <img width="50" height="70" alt="Anime: Noragami" class="lazyload" border="0" data-src="https://myanimelist.cdn-dena.com/r/50x70/images/anime/9/77809.webp?s=8193a880641f2a9cb81b4fee69efdad9" data-srcset="https://myanimelist.cdn-dena.com/r/50x70/images/anime/9/77809.webp?s=8193a880641f2a9cb81b4fee69efdad9 1x, https://myanimelist.cdn-dena.com/r/100x140/images/anime/9/77809.webp?s=ea3d5e36788b783ff7fe609f254435eb 2x" />
+    </a>
+
+    <div class="detail"><div id="area20507">
+  <div id="info20507" rel="a20507" class="hoverinfo"></div>
+</div>
+<div class="di-ib clearfix"><a class="hoverinfo_trigger fl-l fs14 fw-b" href="https://myanimelist.net/anime/20507/Noragami" id="#area20507" rel="#info20507">Noragami</a><a href="https://myanimelist.net/anime/20507/Noragami/video" class="icon-watch ml8" title="Watch Episode Video">Watch Episode Video</a></div><br><div class="information di-ib mt4">
+        TV (12 eps)<br>
+        Jan 2014 - Mar 2014<br>
+        583,469 members
+      </div></div>
+  </td>
+
+    <td class="score ac fs14"><div class="js-top-ranking-score-col di-ib al"><i class="icon-score-star mr4 on"></i><span class="text on">8.17</span></div>
+  </td>
+
+    <td class="your-score ac fs14">
+    <div class="js-top-ranking-your-score-col di-ib al">                        <a href="https://myanimelist.net/panel.php?go=add&amp;selected_series_id=20507&amp;hideLayout" class="Lightbox_AddEdit"><i class="icon-score-star mr4 "></i><span class="text ">N/A</span></a>
+</div>
+  </td>
+
+    <td class="status ac">                        <a href="https://myanimelist.net/panel.php?go=add&amp;selected_series_id=20507&amp;hideLayout" class="Lightbox_AddEdit btn-addEdit-large btn-anime-watch-status js-anime-watch-status notinmylist"><i class="fa fa-plus-square-o mr4"></i>Add to list</a>
+</td>
+</tr>
+
+<tr class="ranking-list">
+    <td class="rank ac" valign="top">
+    <span class="lightLink top-anime-rank-text rank2">27</span>
+  </td>
+    <td class="title al va-t word-break">
+    <a class="hoverinfo_trigger fl-l ml12 mr8" href="https://myanimelist.net/anime/1735/Naruto__Shippuuden" id="#area1735" rel="#info1735">
+      <img width="50" height="70" alt="Anime: Naruto: Shippuuden" class="lazyload" border="0" data-src="https://myanimelist.cdn-dena.com/r/50x70/images/anime/5/17407.webp?s=5519ab4597207266a9ee7fa7b6636560" data-srcset="https://myanimelist.cdn-dena.com/r/50x70/images/anime/5/17407.webp?s=5519ab4597207266a9ee7fa7b6636560 1x, https://myanimelist.cdn-dena.com/r/100x140/images/anime/5/17407.webp?s=0c41adeeeb723a515be975add6577cfe 2x" />
+    </a>
+
+    <div class="detail"><div id="area1735">
+  <div id="info1735" rel="a1735" class="hoverinfo"></div>
+</div>
+<div class="di-ib clearfix"><a class="hoverinfo_trigger fl-l fs14 fw-b" href="https://myanimelist.net/anime/1735/Naruto__Shippuuden" id="#area1735" rel="#info1735">Naruto: Shippuuden</a><a href="https://myanimelist.net/anime/1735/Naruto__Shippuuden/video" class="icon-watch ml8" title="Watch Episode Video">Watch Episode Video</a></div><br><div class="information di-ib mt4">
+        TV (500 eps)<br>
+        Feb 2007 - Mar 2017<br>
+        578,644 members
+      </div></div>
+  </td>
+
+    <td class="score ac fs14"><div class="js-top-ranking-score-col di-ib al"><i class="icon-score-star mr4 on"></i><span class="text on">8.12</span></div>
+  </td>
+
+    <td class="your-score ac fs14">
+    <div class="js-top-ranking-your-score-col di-ib al">                        <a href="https://myanimelist.net/panel.php?go=add&amp;selected_series_id=1735&amp;hideLayout" class="Lightbox_AddEdit"><i class="icon-score-star mr4 "></i><span class="text ">N/A</span></a>
+</div>
+  </td>
+
+    <td class="status ac">                        <a href="https://myanimelist.net/panel.php?go=add&amp;selected_series_id=1735&amp;hideLayout" class="Lightbox_AddEdit btn-addEdit-large btn-anime-watch-status js-anime-watch-status notinmylist"><i class="fa fa-plus-square-o mr4"></i>Add to list</a>
+</td>
+</tr>
+
+<tr class="ranking-list">
+    <td class="rank ac" valign="top">
+    <span class="lightLink top-anime-rank-text rank2">28</span>
+  </td>
+    <td class="title al va-t word-break">
+    <a class="hoverinfo_trigger fl-l ml12 mr8" href="https://myanimelist.net/anime/8074/Highschool_of_the_Dead" id="#area8074" rel="#info8074">
+      <img width="50" height="70" alt="Anime: Highschool of the Dead" class="lazyload" border="0" data-src="https://myanimelist.cdn-dena.com/r/50x70/images/anime/11/78311.webp?s=59eccf22c3b92be3b0e8fe2a126f5d10" data-srcset="https://myanimelist.cdn-dena.com/r/50x70/images/anime/11/78311.webp?s=59eccf22c3b92be3b0e8fe2a126f5d10 1x, https://myanimelist.cdn-dena.com/r/100x140/images/anime/11/78311.webp?s=29a35b770ab4ec89de4ad337be58979f 2x" />
+    </a>
+
+    <div class="detail"><div id="area8074">
+  <div id="info8074" rel="a8074" class="hoverinfo"></div>
+</div>
+<div class="di-ib clearfix"><a class="hoverinfo_trigger fl-l fs14 fw-b" href="https://myanimelist.net/anime/8074/Highschool_of_the_Dead" id="#area8074" rel="#info8074">Highschool of the Dead</a><a href="https://myanimelist.net/anime/8074/Highschool_of_the_Dead/video" class="icon-watch ml8" title="Watch Episode Video">Watch Episode Video</a></div><br><div class="information di-ib mt4">
+        TV (12 eps)<br>
+        Jul 2010 - Sep 2010<br>
+        577,818 members
+      </div></div>
+  </td>
+
+    <td class="score ac fs14"><div class="js-top-ranking-score-col di-ib al"><i class="icon-score-star mr4 on"></i><span class="text on">7.44</span></div>
+  </td>
+
+    <td class="your-score ac fs14">
+    <div class="js-top-ranking-your-score-col di-ib al">                                  <a href="https://myanimelist.net/editlist.php?type=anime&amp;id=8074&amp;hideLayout" class="Lightbox_AddEdit"><i class="icon-score-star mr4 on"></i><span class="text on">7</span></a>
+</div>
+  </td>
+
+    <td class="status ac">                                  <a href="https://myanimelist.net/editlist.php?type=anime&amp;id=8074&amp;hideLayout" class="Lightbox_AddEdit btn-addEdit-large btn-anime-watch-status js-anime-watch-status completed">Completed</a>
+</td>
+</tr>
+
+<tr class="ranking-list">
+    <td class="rank ac" valign="top">
+    <span class="lightLink top-anime-rank-text rank2">29</span>
+  </td>
+    <td class="title al va-t word-break">
+    <a class="hoverinfo_trigger fl-l ml12 mr8" href="https://myanimelist.net/anime/13601/Psycho-Pass" id="#area13601" rel="#info13601">
+      <img width="50" height="70" alt="Anime: Psycho-Pass" class="lazyload" border="0" data-src="https://myanimelist.cdn-dena.com/r/50x70/images/anime/5/43399.webp?s=03b5999dd968047c0538a431fb9fa006" data-srcset="https://myanimelist.cdn-dena.com/r/50x70/images/anime/5/43399.webp?s=03b5999dd968047c0538a431fb9fa006 1x, https://myanimelist.cdn-dena.com/r/100x140/images/anime/5/43399.webp?s=e77262ac5284b1b38e3e242f836e5667 2x" />
+    </a>
+
+    <div class="detail"><div id="area13601">
+  <div id="info13601" rel="a13601" class="hoverinfo"></div>
+</div>
+<div class="di-ib clearfix"><a class="hoverinfo_trigger fl-l fs14 fw-b" href="https://myanimelist.net/anime/13601/Psycho-Pass" id="#area13601" rel="#info13601">Psycho-Pass</a><a href="https://myanimelist.net/anime/13601/Psycho-Pass/video" class="icon-watch ml8" title="Watch Episode Video">Watch Episode Video</a></div><br><div class="information di-ib mt4">
+        TV (22 eps)<br>
+        Oct 2012 - Mar 2013<br>
+        559,471 members
+      </div></div>
+  </td>
+
+    <td class="score ac fs14"><div class="js-top-ranking-score-col di-ib al"><i class="icon-score-star mr4 on"></i><span class="text on">8.49</span></div>
+  </td>
+
+    <td class="your-score ac fs14">
+    <div class="js-top-ranking-your-score-col di-ib al">                                  <a href="https://myanimelist.net/editlist.php?type=anime&amp;id=13601&amp;hideLayout" class="Lightbox_AddEdit"><i class="icon-score-star mr4 "></i><span class="text ">N/A</span></a>
+</div>
+  </td>
+
+    <td class="status ac">                                  <a href="https://myanimelist.net/editlist.php?type=anime&amp;id=13601&amp;hideLayout" class="Lightbox_AddEdit btn-addEdit-large btn-anime-watch-status js-anime-watch-status plantowatch">Plan to Watch</a>
+</td>
+</tr>
+
+<tr class="ranking-list">
+    <td class="rank ac" valign="top">
+    <span class="lightLink top-anime-rank-text rank2">30</span>
+  </td>
+    <td class="title al va-t word-break">
+    <a class="hoverinfo_trigger fl-l ml12 mr8" href="https://myanimelist.net/anime/18679/Kill_la_Kill" id="#area18679" rel="#info18679">
+      <img width="50" height="70" alt="Anime: Kill la Kill" class="lazyload" border="0" data-src="https://myanimelist.cdn-dena.com/r/50x70/images/anime/8/75514.webp?s=250c0c7d3c0ed33f7492efe17f617e3e" data-srcset="https://myanimelist.cdn-dena.com/r/50x70/images/anime/8/75514.webp?s=250c0c7d3c0ed33f7492efe17f617e3e 1x, https://myanimelist.cdn-dena.com/r/100x140/images/anime/8/75514.webp?s=4129cc769a6e7f33ffeb7859bf8d1171 2x" />
+    </a>
+
+    <div class="detail"><div id="area18679">
+  <div id="info18679" rel="a18679" class="hoverinfo"></div>
+</div>
+<div class="di-ib clearfix"><a class="hoverinfo_trigger fl-l fs14 fw-b" href="https://myanimelist.net/anime/18679/Kill_la_Kill" id="#area18679" rel="#info18679">Kill la Kill</a><a href="https://myanimelist.net/anime/18679/Kill_la_Kill/video" class="icon-watch ml8" title="Watch Episode Video">Watch Episode Video</a></div><br><div class="information di-ib mt4">
+        TV (24 eps)<br>
+        Oct 2013 - Mar 2014<br>
+        558,920 members
+      </div></div>
+  </td>
+
+    <td class="score ac fs14"><div class="js-top-ranking-score-col di-ib al"><i class="icon-score-star mr4 on"></i><span class="text on">8.21</span></div>
+  </td>
+
+    <td class="your-score ac fs14">
+    <div class="js-top-ranking-your-score-col di-ib al">                                  <a href="https://myanimelist.net/editlist.php?type=anime&amp;id=18679&amp;hideLayout" class="Lightbox_AddEdit"><i class="icon-score-star mr4 on"></i><span class="text on">10</span></a>
+</div>
+  </td>
+
+    <td class="status ac">                                  <a href="https://myanimelist.net/editlist.php?type=anime&amp;id=18679&amp;hideLayout" class="Lightbox_AddEdit btn-addEdit-large btn-anime-watch-status js-anime-watch-status completed">Completed</a>
+</td>
+</tr>
+
+<tr class="ranking-list">
+    <td class="rank ac" valign="top">
+    <span class="lightLink top-anime-rank-text rank2">31</span>
+  </td>
+    <td class="title al va-t word-break">
+    <a class="hoverinfo_trigger fl-l ml12 mr8" href="https://myanimelist.net/anime/22199/Akame_ga_Kill" id="#area22199" rel="#info22199">
+      <img width="50" height="70" alt="Anime: Akame ga Kill!" class="lazyload" border="0" data-src="https://myanimelist.cdn-dena.com/r/50x70/images/anime/6/78438.webp?s=2a446ef165a0f7f54d280f5b9bb8edf3" data-srcset="https://myanimelist.cdn-dena.com/r/50x70/images/anime/6/78438.webp?s=2a446ef165a0f7f54d280f5b9bb8edf3 1x, https://myanimelist.cdn-dena.com/r/100x140/images/anime/6/78438.webp?s=a89770d8053ab7ac6dfcc0697d6fed35 2x" />
+    </a>
+
+    <div class="detail"><div id="area22199">
+  <div id="info22199" rel="a22199" class="hoverinfo"></div>
+</div>
+<div class="di-ib clearfix"><a class="hoverinfo_trigger fl-l fs14 fw-b" href="https://myanimelist.net/anime/22199/Akame_ga_Kill" id="#area22199" rel="#info22199">Akame ga Kill!</a><a href="https://myanimelist.net/anime/22199/Akame_ga_Kill/video" class="icon-watch ml8" title="Watch Episode Video">Watch Episode Video</a></div><br><div class="information di-ib mt4">
+        TV (24 eps)<br>
+        Jul 2014 - Dec 2014<br>
+        550,725 members
+      </div></div>
+  </td>
+
+    <td class="score ac fs14"><div class="js-top-ranking-score-col di-ib al"><i class="icon-score-star mr4 on"></i><span class="text on">7.83</span></div>
+  </td>
+
+    <td class="your-score ac fs14">
+    <div class="js-top-ranking-your-score-col di-ib al">                                  <a href="https://myanimelist.net/editlist.php?type=anime&amp;id=22199&amp;hideLayout" class="Lightbox_AddEdit"><i class="icon-score-star mr4 on"></i><span class="text on">9</span></a>
+</div>
+  </td>
+
+    <td class="status ac">                                  <a href="https://myanimelist.net/editlist.php?type=anime&amp;id=22199&amp;hideLayout" class="Lightbox_AddEdit btn-addEdit-large btn-anime-watch-status js-anime-watch-status completed">Completed</a>
+</td>
+</tr>
+
+<tr class="ranking-list">
+    <td class="rank ac" valign="top">
+    <span class="lightLink top-anime-rank-text rank2">32</span>
+  </td>
+    <td class="title al va-t word-break">
+    <a class="hoverinfo_trigger fl-l ml12 mr8" href="https://myanimelist.net/anime/21/One_Piece" id="#area21" rel="#info21">
+      <img width="50" height="70" alt="Anime: One Piece" class="lazyload" border="0" data-src="https://myanimelist.cdn-dena.com/r/50x70/images/anime/6/73245.webp?s=c8ce61af081779acd201220cc1eb540b" data-srcset="https://myanimelist.cdn-dena.com/r/50x70/images/anime/6/73245.webp?s=c8ce61af081779acd201220cc1eb540b 1x, https://myanimelist.cdn-dena.com/r/100x140/images/anime/6/73245.webp?s=95382e6f29a0093a04b1479145c18d61 2x" />
+    </a>
+
+    <div class="detail"><div id="area21">
+  <div id="info21" rel="a21" class="hoverinfo"></div>
+</div>
+<div class="di-ib clearfix"><a class="hoverinfo_trigger fl-l fs14 fw-b" href="https://myanimelist.net/anime/21/One_Piece" id="#area21" rel="#info21">One Piece</a><a href="https://myanimelist.net/anime/21/One_Piece/video" class="icon-watch ml8" title="Watch Episode Video">Watch Episode Video</a></div><br><div class="information di-ib mt4">
+        TV (? eps)<br>
+        Oct 1999 - <br>
+        544,961 members
+      </div></div>
+  </td>
+
+    <td class="score ac fs14"><div class="js-top-ranking-score-col di-ib al"><i class="icon-score-star mr4 on"></i><span class="text on">8.57</span></div>
+  </td>
+
+    <td class="your-score ac fs14">
+    <div class="js-top-ranking-your-score-col di-ib al">                        <a href="https://myanimelist.net/panel.php?go=add&amp;selected_series_id=21&amp;hideLayout" class="Lightbox_AddEdit"><i class="icon-score-star mr4 "></i><span class="text ">N/A</span></a>
+</div>
+  </td>
+
+    <td class="status ac">                        <a href="https://myanimelist.net/panel.php?go=add&amp;selected_series_id=21&amp;hideLayout" class="Lightbox_AddEdit btn-addEdit-large btn-anime-watch-status js-anime-watch-status notinmylist"><i class="fa fa-plus-square-o mr4"></i>Add to list</a>
+</td>
+</tr>
+
+<tr class="ranking-list">
+    <td class="rank ac" valign="top">
+    <span class="lightLink top-anime-rank-text rank2">33</span>
+  </td>
+    <td class="title al va-t word-break">
+    <a class="hoverinfo_trigger fl-l ml12 mr8" href="https://myanimelist.net/anime/1/Cowboy_Bebop" id="#area1" rel="#info1">
+      <img width="50" height="70" alt="Anime: Cowboy Bebop" class="lazyload" border="0" data-src="https://myanimelist.cdn-dena.com/r/50x70/images/anime/4/19644.webp?s=7701780d5a9b45e3c371a724b05a2422" data-srcset="https://myanimelist.cdn-dena.com/r/50x70/images/anime/4/19644.webp?s=7701780d5a9b45e3c371a724b05a2422 1x, https://myanimelist.cdn-dena.com/r/100x140/images/anime/4/19644.webp?s=d597b3443c72022065808ca17110bdfc 2x" />
+    </a>
+
+    <div class="detail"><div id="area1">
+  <div id="info1" rel="a1" class="hoverinfo"></div>
+</div>
+<div class="di-ib clearfix"><a class="hoverinfo_trigger fl-l fs14 fw-b" href="https://myanimelist.net/anime/1/Cowboy_Bebop" id="#area1" rel="#info1">Cowboy Bebop</a><a href="https://myanimelist.net/anime/1/Cowboy_Bebop/video" class="icon-watch ml8" title="Watch Episode Video">Watch Episode Video</a></div><br><div class="information di-ib mt4">
+        TV (26 eps)<br>
+        Apr 1998 - Apr 1999<br>
+        527,350 members
+      </div></div>
+  </td>
+
+    <td class="score ac fs14"><div class="js-top-ranking-score-col di-ib al"><i class="icon-score-star mr4 on"></i><span class="text on">8.82</span></div>
+  </td>
+
+    <td class="your-score ac fs14">
+    <div class="js-top-ranking-your-score-col di-ib al">                                  <a href="https://myanimelist.net/editlist.php?type=anime&amp;id=1&amp;hideLayout" class="Lightbox_AddEdit"><i class="icon-score-star mr4 on"></i><span class="text on">10</span></a>
+</div>
+  </td>
+
+    <td class="status ac">                                  <a href="https://myanimelist.net/editlist.php?type=anime&amp;id=1&amp;hideLayout" class="Lightbox_AddEdit btn-addEdit-large btn-anime-watch-status js-anime-watch-status completed">Completed</a>
+</td>
+</tr>
+
+<tr class="ranking-list">
+    <td class="rank ac" valign="top">
+    <span class="lightLink top-anime-rank-text rank2">34</span>
+  </td>
+    <td class="title al va-t word-break">
+    <a class="hoverinfo_trigger fl-l ml12 mr8" href="https://myanimelist.net/anime/5081/Bakemonogatari" id="#area5081" rel="#info5081">
+      <img width="50" height="70" alt="Anime: Bakemonogatari" class="lazyload" border="0" data-src="https://myanimelist.cdn-dena.com/r/50x70/images/anime/11/75274.webp?s=d6a74c1dd6a63a8b8011a4fccc4b0410" data-srcset="https://myanimelist.cdn-dena.com/r/50x70/images/anime/11/75274.webp?s=d6a74c1dd6a63a8b8011a4fccc4b0410 1x, https://myanimelist.cdn-dena.com/r/100x140/images/anime/11/75274.webp?s=1f8296f45ce1f7a2f27bd76d83178870 2x" />
+    </a>
+
+    <div class="detail"><div id="area5081">
+  <div id="info5081" rel="a5081" class="hoverinfo"></div>
+</div>
+<div class="di-ib clearfix"><a class="hoverinfo_trigger fl-l fs14 fw-b" href="https://myanimelist.net/anime/5081/Bakemonogatari" id="#area5081" rel="#info5081">Bakemonogatari</a><a href="https://myanimelist.net/anime/5081/Bakemonogatari/video" class="icon-watch ml8" title="Watch Episode Video">Watch Episode Video</a></div><br><div class="information di-ib mt4">
+        TV (15 eps)<br>
+        Jul 2009 - Jun 2010<br>
+        518,156 members
+      </div></div>
+  </td>
+
+    <td class="score ac fs14"><div class="js-top-ranking-score-col di-ib al"><i class="icon-score-star mr4 on"></i><span class="text on">8.37</span></div>
+  </td>
+
+    <td class="your-score ac fs14">
+    <div class="js-top-ranking-your-score-col di-ib al">                                  <a href="https://myanimelist.net/editlist.php?type=anime&amp;id=5081&amp;hideLayout" class="Lightbox_AddEdit"><i class="icon-score-star mr4 on"></i><span class="text on">10</span></a>
+</div>
+  </td>
+
+    <td class="status ac">                                  <a href="https://myanimelist.net/editlist.php?type=anime&amp;id=5081&amp;hideLayout" class="Lightbox_AddEdit btn-addEdit-large btn-anime-watch-status js-anime-watch-status completed">Completed</a>
+</td>
+</tr>
+
+<tr class="ranking-list">
+    <td class="rank ac" valign="top">
+    <span class="lightLink top-anime-rank-text rank2">35</span>
+  </td>
+    <td class="title al va-t word-break">
+    <a class="hoverinfo_trigger fl-l ml12 mr8" href="https://myanimelist.net/anime/199/Sen_to_Chihiro_no_Kamikakushi" id="#area199" rel="#info199">
+      <img width="50" height="70" alt="Anime: Sen to Chihiro no Kamikakushi" class="lazyload" border="0" data-src="https://myanimelist.cdn-dena.com/r/50x70/images/anime/6/79597.webp?s=a67e3ef6bdeb66c04331e766ce29b44d" data-srcset="https://myanimelist.cdn-dena.com/r/50x70/images/anime/6/79597.webp?s=a67e3ef6bdeb66c04331e766ce29b44d 1x, https://myanimelist.cdn-dena.com/r/100x140/images/anime/6/79597.webp?s=2e5ec7a09615356a24311f1f13752b84 2x" />
+    </a>
+
+    <div class="detail"><div id="area199">
+  <div id="info199" rel="a199" class="hoverinfo"></div>
+</div>
+<div class="di-ib clearfix"><a class="hoverinfo_trigger fl-l fs14 fw-b" href="https://myanimelist.net/anime/199/Sen_to_Chihiro_no_Kamikakushi" id="#area199" rel="#info199">Sen to Chihiro no Kamikakushi</a><a href="https://myanimelist.net/anime/199/Sen_to_Chihiro_no_Kamikakushi/video" class="icon-watch-pv ml8" title="Watch Promotional Video">Watch Promotional Video</a></div><br><div class="information di-ib mt4">
+        Movie (1 eps)<br>
+        Jul 2001 - Jul 2001<br>
+        514,668 members
+      </div></div>
+  </td>
+
+    <td class="score ac fs14"><div class="js-top-ranking-score-col di-ib al"><i class="icon-score-star mr4 on"></i><span class="text on">8.93</span></div>
+  </td>
+
+    <td class="your-score ac fs14">
+    <div class="js-top-ranking-your-score-col di-ib al">                                  <a href="https://myanimelist.net/editlist.php?type=anime&amp;id=199&amp;hideLayout" class="Lightbox_AddEdit"><i class="icon-score-star mr4 on"></i><span class="text on">10</span></a>
+</div>
+  </td>
+
+    <td class="status ac">                                  <a href="https://myanimelist.net/editlist.php?type=anime&amp;id=199&amp;hideLayout" class="Lightbox_AddEdit btn-addEdit-large btn-anime-watch-status js-anime-watch-status completed">Completed</a>
+</td>
+</tr>
+
+<tr class="ranking-list">
+    <td class="rank ac" valign="top">
+    <span class="lightLink top-anime-rank-text rank2">36</span>
+  </td>
+    <td class="title al va-t word-break">
+    <a class="hoverinfo_trigger fl-l ml12 mr8" href="https://myanimelist.net/anime/9989/Ano_Hi_Mita_Hana_no_Namae_wo_Bokutachi_wa_Mada_Shiranai" id="#area9989" rel="#info9989">
+      <img width="50" height="70" alt="Anime: Ano Hi Mita Hana no Namae wo Bokutachi wa Mada Shiranai." class="lazyload" border="0" data-src="https://myanimelist.cdn-dena.com/r/50x70/images/anime/5/79697.webp?s=a8d5d9523817556647c76c667e1d35c5" data-srcset="https://myanimelist.cdn-dena.com/r/50x70/images/anime/5/79697.webp?s=a8d5d9523817556647c76c667e1d35c5 1x, https://myanimelist.cdn-dena.com/r/100x140/images/anime/5/79697.webp?s=fa2381a805ae71d94beacdd16f642882 2x" />
+    </a>
+
+    <div class="detail"><div id="area9989">
+  <div id="info9989" rel="a9989" class="hoverinfo"></div>
+</div>
+<div class="di-ib clearfix"><a class="hoverinfo_trigger fl-l fs14 fw-b" href="https://myanimelist.net/anime/9989/Ano_Hi_Mita_Hana_no_Namae_wo_Bokutachi_wa_Mada_Shiranai" id="#area9989" rel="#info9989">Ano Hi Mita Hana no Namae wo Bokutachi wa Mada Shiranai.</a><a href="https://myanimelist.net/anime/9989/Ano_Hi_Mita_Hana_no_Namae_wo_Bokutachi_wa_Mada_Shiranai/video" class="icon-watch ml8" title="Watch Episode Video">Watch Episode Video</a></div><br><div class="information di-ib mt4">
+        TV (11 eps)<br>
+        Apr 2011 - Jun 2011<br>
+        505,214 members
+      </div></div>
+  </td>
+
+    <td class="score ac fs14"><div class="js-top-ranking-score-col di-ib al"><i class="icon-score-star mr4 on"></i><span class="text on">8.60</span></div>
+  </td>
+
+    <td class="your-score ac fs14">
+    <div class="js-top-ranking-your-score-col di-ib al">                                  <a href="https://myanimelist.net/editlist.php?type=anime&amp;id=9989&amp;hideLayout" class="Lightbox_AddEdit"><i class="icon-score-star mr4 on"></i><span class="text on">10</span></a>
+</div>
+  </td>
+
+    <td class="status ac">                                  <a href="https://myanimelist.net/editlist.php?type=anime&amp;id=9989&amp;hideLayout" class="Lightbox_AddEdit btn-addEdit-large btn-anime-watch-status js-anime-watch-status completed">Completed</a>
+</td>
+</tr>
+
+<tr class="ranking-list">
+    <td class="rank ac" valign="top">
+    <span class="lightLink top-anime-rank-text rank2">37</span>
+  </td>
+    <td class="title al va-t word-break">
+    <a class="hoverinfo_trigger fl-l ml12 mr8" href="https://myanimelist.net/anime/9756/Mahou_Shoujo_Madoka★Magica" id="#area9756" rel="#info9756">
+      <img width="50" height="70" alt="Anime: Mahou Shoujo Madoka★Magica" class="lazyload" border="0" data-src="https://myanimelist.cdn-dena.com/r/50x70/images/anime/11/55225.webp?s=5d1315fd76ecc073b294eb7349d034d4" data-srcset="https://myanimelist.cdn-dena.com/r/50x70/images/anime/11/55225.webp?s=5d1315fd76ecc073b294eb7349d034d4 1x, https://myanimelist.cdn-dena.com/r/100x140/images/anime/11/55225.webp?s=5cab9644be18657cdbe959e36de3b773 2x" />
+    </a>
+
+    <div class="detail"><div id="area9756">
+  <div id="info9756" rel="a9756" class="hoverinfo"></div>
+</div>
+<div class="di-ib clearfix"><a class="hoverinfo_trigger fl-l fs14 fw-b" href="https://myanimelist.net/anime/9756/Mahou_Shoujo_Madoka★Magica" id="#area9756" rel="#info9756">Mahou Shoujo Madoka★Magica</a><a href="https://myanimelist.net/anime/9756/Mahou_Shoujo_Madoka%E2%98%85Magica/video" class="icon-watch ml8" title="Watch Episode Video">Watch Episode Video</a></div><br><div class="information di-ib mt4">
+        TV (12 eps)<br>
+        Jan 2011 - Apr 2011<br>
+        497,904 members
+      </div></div>
+  </td>
+
+    <td class="score ac fs14"><div class="js-top-ranking-score-col di-ib al"><i class="icon-score-star mr4 on"></i><span class="text on">8.50</span></div>
+  </td>
+
+    <td class="your-score ac fs14">
+    <div class="js-top-ranking-your-score-col di-ib al">                                  <a href="https://myanimelist.net/editlist.php?type=anime&amp;id=9756&amp;hideLayout" class="Lightbox_AddEdit"><i class="icon-score-star mr4 on"></i><span class="text on">10</span></a>
+</div>
+  </td>
+
+    <td class="status ac">                                  <a href="https://myanimelist.net/editlist.php?type=anime&amp;id=9756&amp;hideLayout" class="Lightbox_AddEdit btn-addEdit-large btn-anime-watch-status js-anime-watch-status completed">Completed</a>
+</td>
+</tr>
+
+<tr class="ranking-list">
+    <td class="rank ac" valign="top">
+    <span class="lightLink top-anime-rank-text rank2">38</span>
+  </td>
+    <td class="title al va-t word-break">
+    <a class="hoverinfo_trigger fl-l ml12 mr8" href="https://myanimelist.net/anime/10793/Guilty_Crown" id="#area10793" rel="#info10793">
+      <img width="50" height="70" alt="Anime: Guilty Crown" class="lazyload" border="0" data-src="https://myanimelist.cdn-dena.com/r/50x70/images/anime/8/33713.webp?s=da7d9c6380aa15c37aa41bf540fc18cb" data-srcset="https://myanimelist.cdn-dena.com/r/50x70/images/anime/8/33713.webp?s=da7d9c6380aa15c37aa41bf540fc18cb 1x, https://myanimelist.cdn-dena.com/r/100x140/images/anime/8/33713.webp?s=1bec012504a07bf23721502a8974051d 2x" />
+    </a>
+
+    <div class="detail"><div id="area10793">
+  <div id="info10793" rel="a10793" class="hoverinfo"></div>
+</div>
+<div class="di-ib clearfix"><a class="hoverinfo_trigger fl-l fs14 fw-b" href="https://myanimelist.net/anime/10793/Guilty_Crown" id="#area10793" rel="#info10793">Guilty Crown</a><a href="https://myanimelist.net/anime/10793/Guilty_Crown/video" class="icon-watch-pv ml8" title="Watch Promotional Video">Watch Promotional Video</a></div><br><div class="information di-ib mt4">
+        TV (22 eps)<br>
+        Oct 2011 - Mar 2012<br>
+        497,357 members
+      </div></div>
+  </td>
+
+    <td class="score ac fs14"><div class="js-top-ranking-score-col di-ib al"><i class="icon-score-star mr4 on"></i><span class="text on">7.80</span></div>
+  </td>
+
+    <td class="your-score ac fs14">
+    <div class="js-top-ranking-your-score-col di-ib al">                                  <a href="https://myanimelist.net/editlist.php?type=anime&amp;id=10793&amp;hideLayout" class="Lightbox_AddEdit"><i class="icon-score-star mr4 "></i><span class="text ">N/A</span></a>
+</div>
+  </td>
+
+    <td class="status ac">                                  <a href="https://myanimelist.net/editlist.php?type=anime&amp;id=10793&amp;hideLayout" class="Lightbox_AddEdit btn-addEdit-large btn-anime-watch-status js-anime-watch-status plantowatch">Plan to Watch</a>
+</td>
+</tr>
+
+<tr class="ranking-list">
+    <td class="rank ac" valign="top">
+    <span class="lightLink top-anime-rank-text rank2">39</span>
+  </td>
+    <td class="title al va-t word-break">
+    <a class="hoverinfo_trigger fl-l ml12 mr8" href="https://myanimelist.net/anime/10087/Fate_Zero" id="#area10087" rel="#info10087">
+      <img width="50" height="70" alt="Anime: Fate/Zero" class="lazyload" border="0" data-src="https://myanimelist.cdn-dena.com/r/50x70/images/anime/2/73249.webp?s=86ca2d6a5bd5c8abf01e7c7d0e6265f9" data-srcset="https://myanimelist.cdn-dena.com/r/50x70/images/anime/2/73249.webp?s=86ca2d6a5bd5c8abf01e7c7d0e6265f9 1x, https://myanimelist.cdn-dena.com/r/100x140/images/anime/2/73249.webp?s=f186b3e7708040b995099194d8d8176c 2x" />
+    </a>
+
+    <div class="detail"><div id="area10087">
+  <div id="info10087" rel="a10087" class="hoverinfo"></div>
+</div>
+<div class="di-ib clearfix"><a class="hoverinfo_trigger fl-l fs14 fw-b" href="https://myanimelist.net/anime/10087/Fate_Zero" id="#area10087" rel="#info10087">Fate/Zero</a><a href="https://myanimelist.net/anime/10087/Fate_Zero/video" class="icon-watch ml8" title="Watch Episode Video">Watch Episode Video</a></div><br><div class="information di-ib mt4">
+        TV (13 eps)<br>
+        Oct 2011 - Dec 2011<br>
+        496,392 members
+      </div></div>
+  </td>
+
+    <td class="score ac fs14"><div class="js-top-ranking-score-col di-ib al"><i class="icon-score-star mr4 on"></i><span class="text on">8.49</span></div>
+  </td>
+
+    <td class="your-score ac fs14">
+    <div class="js-top-ranking-your-score-col di-ib al">                                  <a href="https://myanimelist.net/editlist.php?type=anime&amp;id=10087&amp;hideLayout" class="Lightbox_AddEdit"><i class="icon-score-star mr4 "></i><span class="text ">N/A</span></a>
+</div>
+  </td>
+
+    <td class="status ac">                                  <a href="https://myanimelist.net/editlist.php?type=anime&amp;id=10087&amp;hideLayout" class="Lightbox_AddEdit btn-addEdit-large btn-anime-watch-status js-anime-watch-status plantowatch">Plan to Watch</a>
+</td>
+</tr>
+
+<tr class="ranking-list">
+    <td class="rank ac" valign="top">
+    <span class="lightLink top-anime-rank-text rank2">40</span>
+  </td>
+    <td class="title al va-t word-break">
+    <a class="hoverinfo_trigger fl-l ml12 mr8" href="https://myanimelist.net/anime/30/Neon_Genesis_Evangelion" id="#area30" rel="#info30">
+      <img width="50" height="70" alt="Anime: Neon Genesis Evangelion" class="lazyload" border="0" data-src="https://myanimelist.cdn-dena.com/r/50x70/images/anime/12/21418.webp?s=460e80601450fb1b0e4e1b213aecc0de" data-srcset="https://myanimelist.cdn-dena.com/r/50x70/images/anime/12/21418.webp?s=460e80601450fb1b0e4e1b213aecc0de 1x, https://myanimelist.cdn-dena.com/r/100x140/images/anime/12/21418.webp?s=c921a77354d5dd8c071f6bccf2ba5437 2x" />
+    </a>
+
+    <div class="detail"><div id="area30">
+  <div id="info30" rel="a30" class="hoverinfo"></div>
+</div>
+<div class="di-ib clearfix"><a class="hoverinfo_trigger fl-l fs14 fw-b" href="https://myanimelist.net/anime/30/Neon_Genesis_Evangelion" id="#area30" rel="#info30">Neon Genesis Evangelion</a><a href="https://myanimelist.net/anime/30/Neon_Genesis_Evangelion/video" class="icon-watch-pv ml8" title="Watch Promotional Video">Watch Promotional Video</a></div><br><div class="information di-ib mt4">
+        TV (26 eps)<br>
+        Oct 1995 - Mar 1996<br>
+        495,726 members
+      </div></div>
+  </td>
+
+    <td class="score ac fs14"><div class="js-top-ranking-score-col di-ib al"><i class="icon-score-star mr4 on"></i><span class="text on">8.32</span></div>
+  </td>
+
+    <td class="your-score ac fs14">
+    <div class="js-top-ranking-your-score-col di-ib al">                        <a href="https://myanimelist.net/panel.php?go=add&amp;selected_series_id=30&amp;hideLayout" class="Lightbox_AddEdit"><i class="icon-score-star mr4 "></i><span class="text ">N/A</span></a>
+</div>
+  </td>
+
+    <td class="status ac">                        <a href="https://myanimelist.net/panel.php?go=add&amp;selected_series_id=30&amp;hideLayout" class="Lightbox_AddEdit btn-addEdit-large btn-anime-watch-status js-anime-watch-status notinmylist"><i class="fa fa-plus-square-o mr4"></i>Add to list</a>
+</td>
+</tr>
+
+<tr class="ranking-list">
+    <td class="rank ac" valign="top">
+    <span class="lightLink top-anime-rank-text rank2">41</span>
+  </td>
+    <td class="title al va-t word-break">
+    <a class="hoverinfo_trigger fl-l ml12 mr8" href="https://myanimelist.net/anime/6880/Deadman_Wonderland" id="#area6880" rel="#info6880">
+      <img width="50" height="70" alt="Anime: Deadman Wonderland" class="lazyload" border="0" data-src="https://myanimelist.cdn-dena.com/r/50x70/images/anime/9/75299.webp?s=c5702cc1bca0589f2e7385b6cbf9fd11" data-srcset="https://myanimelist.cdn-dena.com/r/50x70/images/anime/9/75299.webp?s=c5702cc1bca0589f2e7385b6cbf9fd11 1x, https://myanimelist.cdn-dena.com/r/100x140/images/anime/9/75299.webp?s=0a1e4e15de4d195d087c13141964eb9c 2x" />
+    </a>
+
+    <div class="detail"><div id="area6880">
+  <div id="info6880" rel="a6880" class="hoverinfo"></div>
+</div>
+<div class="di-ib clearfix"><a class="hoverinfo_trigger fl-l fs14 fw-b" href="https://myanimelist.net/anime/6880/Deadman_Wonderland" id="#area6880" rel="#info6880">Deadman Wonderland</a><a href="https://myanimelist.net/anime/6880/Deadman_Wonderland/video" class="icon-watch ml8" title="Watch Episode Video">Watch Episode Video</a></div><br><div class="information di-ib mt4">
+        TV (12 eps)<br>
+        Apr 2011 - Jul 2011<br>
+        489,162 members
+      </div></div>
+  </td>
+
+    <td class="score ac fs14"><div class="js-top-ranking-score-col di-ib al"><i class="icon-score-star mr4 on"></i><span class="text on">7.47</span></div>
+  </td>
+
+    <td class="your-score ac fs14">
+    <div class="js-top-ranking-your-score-col di-ib al">                        <a href="https://myanimelist.net/panel.php?go=add&amp;selected_series_id=6880&amp;hideLayout" class="Lightbox_AddEdit"><i class="icon-score-star mr4 "></i><span class="text ">N/A</span></a>
+</div>
+  </td>
+
+    <td class="status ac">                        <a href="https://myanimelist.net/panel.php?go=add&amp;selected_series_id=6880&amp;hideLayout" class="Lightbox_AddEdit btn-addEdit-large btn-anime-watch-status js-anime-watch-status notinmylist"><i class="fa fa-plus-square-o mr4"></i>Add to list</a>
+</td>
+</tr>
+
+<tr class="ranking-list">
+    <td class="rank ac" valign="top">
+    <span class="lightLink top-anime-rank-text rank2">42</span>
+  </td>
+    <td class="title al va-t word-break">
+    <a class="hoverinfo_trigger fl-l ml12 mr8" href="https://myanimelist.net/anime/4181/Clannad__After_Story" id="#area4181" rel="#info4181">
+      <img width="50" height="70" alt="Anime: Clannad: After Story" class="lazyload" border="0" data-src="https://myanimelist.cdn-dena.com/r/50x70/images/anime/13/24647.webp?s=092ac75190c791aec3fa30a1b6e06231" data-srcset="https://myanimelist.cdn-dena.com/r/50x70/images/anime/13/24647.webp?s=092ac75190c791aec3fa30a1b6e06231 1x, https://myanimelist.cdn-dena.com/r/100x140/images/anime/13/24647.webp?s=34e6b0db0d7056e33b341a23ddb00103 2x" />
+    </a>
+
+    <div class="detail"><div id="area4181">
+  <div id="info4181" rel="a4181" class="hoverinfo"></div>
+</div>
+<div class="di-ib clearfix"><a class="hoverinfo_trigger fl-l fs14 fw-b" href="https://myanimelist.net/anime/4181/Clannad__After_Story" id="#area4181" rel="#info4181">Clannad: After Story</a><a href="https://myanimelist.net/anime/4181/Clannad__After_Story/video" class="icon-watch ml8" title="Watch Episode Video">Watch Episode Video</a></div><br><div class="information di-ib mt4">
+        TV (24 eps)<br>
+        Oct 2008 - Mar 2009<br>
+        487,516 members
+      </div></div>
+  </td>
+
+    <td class="score ac fs14"><div class="js-top-ranking-score-col di-ib al"><i class="icon-score-star mr4 on"></i><span class="text on">9.05</span></div>
+  </td>
+
+    <td class="your-score ac fs14">
+    <div class="js-top-ranking-your-score-col di-ib al">                                  <a href="https://myanimelist.net/editlist.php?type=anime&amp;id=4181&amp;hideLayout" class="Lightbox_AddEdit"><i class="icon-score-star mr4 on"></i><span class="text on">10</span></a>
+</div>
+  </td>
+
+    <td class="status ac">                                  <a href="https://myanimelist.net/editlist.php?type=anime&amp;id=4181&amp;hideLayout" class="Lightbox_AddEdit btn-addEdit-large btn-anime-watch-status js-anime-watch-status completed">Completed</a>
+</td>
+</tr>
+
+<tr class="ranking-list">
+    <td class="rank ac" valign="top">
+    <span class="lightLink top-anime-rank-text rank2">43</span>
+  </td>
+    <td class="title al va-t word-break">
+    <a class="hoverinfo_trigger fl-l ml12 mr8" href="https://myanimelist.net/anime/11061/Hunter_x_Hunter_2011" id="#area11061" rel="#info11061">
+      <img width="50" height="70" alt="Anime: Hunter x Hunter (2011)" class="lazyload" border="0" data-src="https://myanimelist.cdn-dena.com/r/50x70/images/anime/11/33657.webp?s=23be891e773e777e8bb33379f99e085c" data-srcset="https://myanimelist.cdn-dena.com/r/50x70/images/anime/11/33657.webp?s=23be891e773e777e8bb33379f99e085c 1x, https://myanimelist.cdn-dena.com/r/100x140/images/anime/11/33657.webp?s=372e58065a3431c5737bf85c683551e8 2x" />
+    </a>
+
+    <div class="detail"><div id="area11061">
+  <div id="info11061" rel="a11061" class="hoverinfo"></div>
+</div>
+<div class="di-ib clearfix"><a class="hoverinfo_trigger fl-l fs14 fw-b" href="https://myanimelist.net/anime/11061/Hunter_x_Hunter_2011" id="#area11061" rel="#info11061">Hunter x Hunter (2011)</a><a href="https://myanimelist.net/anime/11061/Hunter_x_Hunter_2011/video" class="icon-watch ml8" title="Watch Episode Video">Watch Episode Video</a></div><br><div class="information di-ib mt4">
+        TV (148 eps)<br>
+        Oct 2011 - Sep 2014<br>
+        480,120 members
+      </div></div>
+  </td>
+
+    <td class="score ac fs14"><div class="js-top-ranking-score-col di-ib al"><i class="icon-score-star mr4 on"></i><span class="text on">9.13</span></div>
+  </td>
+
+    <td class="your-score ac fs14">
+    <div class="js-top-ranking-your-score-col di-ib al">                        <a href="https://myanimelist.net/panel.php?go=add&amp;selected_series_id=11061&amp;hideLayout" class="Lightbox_AddEdit"><i class="icon-score-star mr4 "></i><span class="text ">N/A</span></a>
+</div>
+  </td>
+
+    <td class="status ac">                        <a href="https://myanimelist.net/panel.php?go=add&amp;selected_series_id=11061&amp;hideLayout" class="Lightbox_AddEdit btn-addEdit-large btn-anime-watch-status js-anime-watch-status notinmylist"><i class="fa fa-plus-square-o mr4"></i>Add to list</a>
+</td>
+</tr>
+
+<tr class="ranking-list">
+    <td class="rank ac" valign="top">
+    <span class="lightLink top-anime-rank-text rank2">44</span>
+  </td>
+    <td class="title al va-t word-break">
+    <a class="hoverinfo_trigger fl-l ml12 mr8" href="https://myanimelist.net/anime/23273/Shigatsu_wa_Kimi_no_Uso" id="#area23273" rel="#info23273">
+      <img width="50" height="70" alt="Anime: Shigatsu wa Kimi no Uso" class="lazyload" border="0" data-src="https://myanimelist.cdn-dena.com/r/50x70/images/anime/3/67177.webp?s=004455b3d3269e57bc24ce47e5758b4e" data-srcset="https://myanimelist.cdn-dena.com/r/50x70/images/anime/3/67177.webp?s=004455b3d3269e57bc24ce47e5758b4e 1x, https://myanimelist.cdn-dena.com/r/100x140/images/anime/3/67177.webp?s=b615c1e85ae007497c21634e65bc331f 2x" />
+    </a>
+
+    <div class="detail"><div id="area23273">
+  <div id="info23273" rel="a23273" class="hoverinfo"></div>
+</div>
+<div class="di-ib clearfix"><a class="hoverinfo_trigger fl-l fs14 fw-b" href="https://myanimelist.net/anime/23273/Shigatsu_wa_Kimi_no_Uso" id="#area23273" rel="#info23273">Shigatsu wa Kimi no Uso</a><a href="https://myanimelist.net/anime/23273/Shigatsu_wa_Kimi_no_Uso/video" class="icon-watch ml8" title="Watch Episode Video">Watch Episode Video</a></div><br><div class="information di-ib mt4">
+        TV (22 eps)<br>
+        Oct 2014 - Mar 2015<br>
+        478,275 members
+      </div></div>
+  </td>
+
+    <td class="score ac fs14"><div class="js-top-ranking-score-col di-ib al"><i class="icon-score-star mr4 on"></i><span class="text on">8.92</span></div>
+  </td>
+
+    <td class="your-score ac fs14">
+    <div class="js-top-ranking-your-score-col di-ib al">                                  <a href="https://myanimelist.net/editlist.php?type=anime&amp;id=23273&amp;hideLayout" class="Lightbox_AddEdit"><i class="icon-score-star mr4 on"></i><span class="text on">10</span></a>
+</div>
+  </td>
+
+    <td class="status ac">                                  <a href="https://myanimelist.net/editlist.php?type=anime&amp;id=23273&amp;hideLayout" class="Lightbox_AddEdit btn-addEdit-large btn-anime-watch-status js-anime-watch-status completed">Completed</a>
+</td>
+</tr>
+
+<tr class="ranking-list">
+    <td class="rank ac" valign="top">
+    <span class="lightLink top-anime-rank-text rank2">45</span>
+  </td>
+    <td class="title al va-t word-break">
+    <a class="hoverinfo_trigger fl-l ml12 mr8" href="https://myanimelist.net/anime/22535/Kiseijuu__Sei_no_Kakuritsu" id="#area22535" rel="#info22535">
+      <img width="50" height="70" alt="Anime: Kiseijuu: Sei no Kakuritsu" class="lazyload" border="0" data-src="https://myanimelist.cdn-dena.com/r/50x70/images/anime/3/73178.webp?s=49431745b81085c82d86994a05f3b91c" data-srcset="https://myanimelist.cdn-dena.com/r/50x70/images/anime/3/73178.webp?s=49431745b81085c82d86994a05f3b91c 1x, https://myanimelist.cdn-dena.com/r/100x140/images/anime/3/73178.webp?s=bd6a2446d4a45f3d75eaf291f1aef2fa 2x" />
+    </a>
+
+    <div class="detail"><div id="area22535">
+  <div id="info22535" rel="a22535" class="hoverinfo"></div>
+</div>
+<div class="di-ib clearfix"><a class="hoverinfo_trigger fl-l fs14 fw-b" href="https://myanimelist.net/anime/22535/Kiseijuu__Sei_no_Kakuritsu" id="#area22535" rel="#info22535">Kiseijuu: Sei no Kakuritsu</a><a href="https://myanimelist.net/anime/22535/Kiseijuu__Sei_no_Kakuritsu/video" class="icon-watch ml8" title="Watch Episode Video">Watch Episode Video</a></div><br><div class="information di-ib mt4">
+        TV (24 eps)<br>
+        Oct 2014 - Mar 2015<br>
+        476,074 members
+      </div></div>
+  </td>
+
+    <td class="score ac fs14"><div class="js-top-ranking-score-col di-ib al"><i class="icon-score-star mr4 on"></i><span class="text on">8.57</span></div>
+  </td>
+
+    <td class="your-score ac fs14">
+    <div class="js-top-ranking-your-score-col di-ib al">                        <a href="https://myanimelist.net/panel.php?go=add&amp;selected_series_id=22535&amp;hideLayout" class="Lightbox_AddEdit"><i class="icon-score-star mr4 "></i><span class="text ">N/A</span></a>
+</div>
+  </td>
+
+    <td class="status ac">                        <a href="https://myanimelist.net/panel.php?go=add&amp;selected_series_id=22535&amp;hideLayout" class="Lightbox_AddEdit btn-addEdit-large btn-anime-watch-status js-anime-watch-status notinmylist"><i class="fa fa-plus-square-o mr4"></i>Add to list</a>
+</td>
+</tr>
+
+<tr class="ranking-list">
+    <td class="rank ac" valign="top">
+    <span class="lightLink top-anime-rank-text rank2">46</span>
+  </td>
+    <td class="title al va-t word-break">
+    <a class="hoverinfo_trigger fl-l ml12 mr8" href="https://myanimelist.net/anime/31043/Boku_dake_ga_Inai_Machi" id="#area31043" rel="#info31043">
+      <img width="50" height="70" alt="Anime: Boku dake ga Inai Machi" class="lazyload" border="0" data-src="https://myanimelist.cdn-dena.com/r/50x70/images/anime/10/77957.webp?s=9f1b32d34efb933ec94d261a52f3d83d" data-srcset="https://myanimelist.cdn-dena.com/r/50x70/images/anime/10/77957.webp?s=9f1b32d34efb933ec94d261a52f3d83d 1x, https://myanimelist.cdn-dena.com/r/100x140/images/anime/10/77957.webp?s=42a854a8cb3381f0262fe3b013524566 2x" />
+    </a>
+
+    <div class="detail"><div id="area31043">
+  <div id="info31043" rel="a31043" class="hoverinfo"></div>
+</div>
+<div class="di-ib clearfix"><a class="hoverinfo_trigger fl-l fs14 fw-b" href="https://myanimelist.net/anime/31043/Boku_dake_ga_Inai_Machi" id="#area31043" rel="#info31043">Boku dake ga Inai Machi</a><a href="https://myanimelist.net/anime/31043/Boku_dake_ga_Inai_Machi/video" class="icon-watch ml8" title="Watch Episode Video">Watch Episode Video</a></div><br><div class="information di-ib mt4">
+        TV (12 eps)<br>
+        Jan 2016 - Mar 2016<br>
+        469,827 members
+      </div></div>
+  </td>
+
+    <td class="score ac fs14"><div class="js-top-ranking-score-col di-ib al"><i class="icon-score-star mr4 on"></i><span class="text on">8.62</span></div>
+  </td>
+
+    <td class="your-score ac fs14">
+    <div class="js-top-ranking-your-score-col di-ib al">                                  <a href="https://myanimelist.net/editlist.php?type=anime&amp;id=31043&amp;hideLayout" class="Lightbox_AddEdit"><i class="icon-score-star mr4 on"></i><span class="text on">10</span></a>
+</div>
+  </td>
+
+    <td class="status ac">                                  <a href="https://myanimelist.net/editlist.php?type=anime&amp;id=31043&amp;hideLayout" class="Lightbox_AddEdit btn-addEdit-large btn-anime-watch-status js-anime-watch-status completed">Completed</a>
+</td>
+</tr>
+
+<tr class="ranking-list">
+    <td class="rank ac" valign="top">
+    <span class="lightLink top-anime-rank-text rank2">47</span>
+  </td>
+    <td class="title al va-t word-break">
+    <a class="hoverinfo_trigger fl-l ml12 mr8" href="https://myanimelist.net/anime/2025/Darker_than_Black__Kuro_no_Keiyakusha" id="#area2025" rel="#info2025">
+      <img width="50" height="70" alt="Anime: Darker than Black: Kuro no Keiyakusha" class="lazyload" border="0" data-src="https://myanimelist.cdn-dena.com/r/50x70/images/anime/5/19570.webp?s=f1258bc848212efe9389bb7ed22f1674" data-srcset="https://myanimelist.cdn-dena.com/r/50x70/images/anime/5/19570.webp?s=f1258bc848212efe9389bb7ed22f1674 1x, https://myanimelist.cdn-dena.com/r/100x140/images/anime/5/19570.webp?s=916196a92a3a67f0cfaa8a82ddbf4a15 2x" />
+    </a>
+
+    <div class="detail"><div id="area2025">
+  <div id="info2025" rel="a2025" class="hoverinfo"></div>
+</div>
+<div class="di-ib clearfix"><a class="hoverinfo_trigger fl-l fs14 fw-b" href="https://myanimelist.net/anime/2025/Darker_than_Black__Kuro_no_Keiyakusha" id="#area2025" rel="#info2025">Darker than Black: Kuro no Keiyakusha</a></div><br><div class="information di-ib mt4">
+        TV (25 eps)<br>
+        Apr 2007 - Sep 2007<br>
+        466,988 members
+      </div></div>
+  </td>
+
+    <td class="score ac fs14"><div class="js-top-ranking-score-col di-ib al"><i class="icon-score-star mr4 on"></i><span class="text on">8.24</span></div>
+  </td>
+
+    <td class="your-score ac fs14">
+    <div class="js-top-ranking-your-score-col di-ib al">                                  <a href="https://myanimelist.net/editlist.php?type=anime&amp;id=2025&amp;hideLayout" class="Lightbox_AddEdit"><i class="icon-score-star mr4 on"></i><span class="text on">9</span></a>
+</div>
+  </td>
+
+    <td class="status ac">                                  <a href="https://myanimelist.net/editlist.php?type=anime&amp;id=2025&amp;hideLayout" class="Lightbox_AddEdit btn-addEdit-large btn-anime-watch-status js-anime-watch-status completed">Completed</a>
+</td>
+</tr>
+
+<tr class="ranking-list">
+    <td class="rank ac" valign="top">
+    <span class="lightLink top-anime-rank-text rank2">48</span>
+  </td>
+    <td class="title al va-t word-break">
+    <a class="hoverinfo_trigger fl-l ml12 mr8" href="https://myanimelist.net/anime/27899/Tokyo_Ghoul_√A" id="#area27899" rel="#info27899">
+      <img width="50" height="70" alt="Anime: Tokyo Ghoul √A" class="lazyload" border="0" data-src="https://myanimelist.cdn-dena.com/r/50x70/images/anime/13/71777.webp?s=0581c5997495911701ee98732ec8f1e1" data-srcset="https://myanimelist.cdn-dena.com/r/50x70/images/anime/13/71777.webp?s=0581c5997495911701ee98732ec8f1e1 1x, https://myanimelist.cdn-dena.com/r/100x140/images/anime/13/71777.webp?s=89cee208ceff15be9525fda7fc12b638 2x" />
+    </a>
+
+    <div class="detail"><div id="area27899">
+  <div id="info27899" rel="a27899" class="hoverinfo"></div>
+</div>
+<div class="di-ib clearfix"><a class="hoverinfo_trigger fl-l fs14 fw-b" href="https://myanimelist.net/anime/27899/Tokyo_Ghoul_√A" id="#area27899" rel="#info27899">Tokyo Ghoul √A</a><a href="https://myanimelist.net/anime/27899/Tokyo_Ghoul_%E2%88%9AA/video" class="icon-watch-pv ml8" title="Watch Promotional Video">Watch Promotional Video</a></div><br><div class="information di-ib mt4">
+        TV (12 eps)<br>
+        Jan 2015 - Mar 2015<br>
+        462,895 members
+      </div></div>
+  </td>
+
+    <td class="score ac fs14"><div class="js-top-ranking-score-col di-ib al"><i class="icon-score-star mr4 on"></i><span class="text on">7.51</span></div>
+  </td>
+
+    <td class="your-score ac fs14">
+    <div class="js-top-ranking-your-score-col di-ib al">                        <a href="https://myanimelist.net/panel.php?go=add&amp;selected_series_id=27899&amp;hideLayout" class="Lightbox_AddEdit"><i class="icon-score-star mr4 "></i><span class="text ">N/A</span></a>
+</div>
+  </td>
+
+    <td class="status ac">                        <a href="https://myanimelist.net/panel.php?go=add&amp;selected_series_id=27899&amp;hideLayout" class="Lightbox_AddEdit btn-addEdit-large btn-anime-watch-status js-anime-watch-status notinmylist"><i class="fa fa-plus-square-o mr4"></i>Add to list</a>
+</td>
+</tr>
+
+<tr class="ranking-list">
+    <td class="rank ac" valign="top">
+    <span class="lightLink top-anime-rank-text rank2">49</span>
+  </td>
+    <td class="title al va-t word-break">
+    <a class="hoverinfo_trigger fl-l ml12 mr8" href="https://myanimelist.net/anime/15809/Hataraku_Maou-sama" id="#area15809" rel="#info15809">
+      <img width="50" height="70" alt="Anime: Hataraku Maou-sama!" class="lazyload" border="0" data-src="https://myanimelist.cdn-dena.com/r/50x70/images/anime/3/50177.webp?s=8528d460fedd8848221c9ef7192147cd" data-srcset="https://myanimelist.cdn-dena.com/r/50x70/images/anime/3/50177.webp?s=8528d460fedd8848221c9ef7192147cd 1x, https://myanimelist.cdn-dena.com/r/100x140/images/anime/3/50177.webp?s=e65d303a2d85ec300e204c6305cce5d0 2x" />
+    </a>
+
+    <div class="detail"><div id="area15809">
+  <div id="info15809" rel="a15809" class="hoverinfo"></div>
+</div>
+<div class="di-ib clearfix"><a class="hoverinfo_trigger fl-l fs14 fw-b" href="https://myanimelist.net/anime/15809/Hataraku_Maou-sama" id="#area15809" rel="#info15809">Hataraku Maou-sama!</a><a href="https://myanimelist.net/anime/15809/Hataraku_Maou-sama/video" class="icon-watch-pv ml8" title="Watch Promotional Video">Watch Promotional Video</a></div><br><div class="information di-ib mt4">
+        TV (13 eps)<br>
+        Apr 2013 - Jun 2013<br>
+        456,043 members
+      </div></div>
+  </td>
+
+    <td class="score ac fs14"><div class="js-top-ranking-score-col di-ib al"><i class="icon-score-star mr4 on"></i><span class="text on">8.02</span></div>
+  </td>
+
+    <td class="your-score ac fs14">
+    <div class="js-top-ranking-your-score-col di-ib al">                                  <a href="https://myanimelist.net/editlist.php?type=anime&amp;id=15809&amp;hideLayout" class="Lightbox_AddEdit"><i class="icon-score-star mr4 on"></i><span class="text on">10</span></a>
+</div>
+  </td>
+
+    <td class="status ac">                                  <a href="https://myanimelist.net/editlist.php?type=anime&amp;id=15809&amp;hideLayout" class="Lightbox_AddEdit btn-addEdit-large btn-anime-watch-status js-anime-watch-status completed">Completed</a>
+</td>
+</tr>
+
+<tr class="ranking-list">
+    <td class="rank ac" valign="top">
+    <span class="lightLink top-anime-rank-text rank2">50</span>
+  </td>
+    <td class="title al va-t word-break">
+    <a class="hoverinfo_trigger fl-l ml12 mr8" href="https://myanimelist.net/anime/4898/Kuroshitsuji" id="#area4898" rel="#info4898">
+      <img width="50" height="70" alt="Anime: Kuroshitsuji" class="lazyload" border="0" data-src="https://myanimelist.cdn-dena.com/r/50x70/images/anime/5/27013.webp?s=335f3de13d5ac34ec62525f463c57fbf" data-srcset="https://myanimelist.cdn-dena.com/r/50x70/images/anime/5/27013.webp?s=335f3de13d5ac34ec62525f463c57fbf 1x, https://myanimelist.cdn-dena.com/r/100x140/images/anime/5/27013.webp?s=5eba7579c578d3b1d1816d3e32490662 2x" />
+    </a>
+
+    <div class="detail"><div id="area4898">
+  <div id="info4898" rel="a4898" class="hoverinfo"></div>
+</div>
+<div class="di-ib clearfix"><a class="hoverinfo_trigger fl-l fs14 fw-b" href="https://myanimelist.net/anime/4898/Kuroshitsuji" id="#area4898" rel="#info4898">Kuroshitsuji</a><a href="https://myanimelist.net/anime/4898/Kuroshitsuji/video" class="icon-watch ml8" title="Watch Episode Video">Watch Episode Video</a></div><br><div class="information di-ib mt4">
+        TV (24 eps)<br>
+        Oct 2008 - Mar 2009<br>
+        454,535 members
+      </div></div>
+  </td>
+
+    <td class="score ac fs14"><div class="js-top-ranking-score-col di-ib al"><i class="icon-score-star mr4 on"></i><span class="text on">8.05</span></div>
+  </td>
+
+    <td class="your-score ac fs14">
+    <div class="js-top-ranking-your-score-col di-ib al">                        <a href="https://myanimelist.net/panel.php?go=add&amp;selected_series_id=4898&amp;hideLayout" class="Lightbox_AddEdit"><i class="icon-score-star mr4 "></i><span class="text ">N/A</span></a>
+</div>
+  </td>
+
+    <td class="status ac">                        <a href="https://myanimelist.net/panel.php?go=add&amp;selected_series_id=4898&amp;hideLayout" class="Lightbox_AddEdit btn-addEdit-large btn-anime-watch-status js-anime-watch-status notinmylist"><i class="fa fa-plus-square-o mr4"></i>Add to list</a>
+</td>
+</tr>
+</table><div class="di-b ac pt16 pb16 pagination icon-top-ranking-page-bottom"><a href="?type=bypopularity&limit=50" class="link-blue-box next">Next 50<i class="fa fa-chevron-right ml4"></i></a></div>
+</div>  <div class="mauto clearfix pt24" style="width:760px;">
+    <div class="fl-l">
+
+        <div class="_unit " style="width:336px;display: block !important;" data-height="280">
+      <div id="pc_anime_top_bottom_rec_l" class="" style="width:336px;">
+        <script type='text/javascript'>
+          googletag.cmd.push(function() {
+                      var slot = googletag.defineSlot("/84947469/pc_anime_top_bottom_rec_l", [[300,250],[336,280],[1,1]], "pc_anime_top_bottom_rec_l").addService(googletag.pubads())
+      .setTargeting("adult", "white").setCollapseEmptyDiv(true,true);googletag.enableServices();
+
+      googletag.display("pc_anime_top_bottom_rec_l");
+              });</script>
+      </div>
+    </div>  </div>
+      <div class="fl-r">
+
+        <div class="_unit " style="width:336px;display: block !important;" data-height="280">
+      <div id="pc_anime_top_bottom_rec_r" class="" style="width:336px;">
+        <script type='text/javascript'>
+          googletag.cmd.push(function() {
+                      var slot = googletag.defineSlot("/84947469/pc_anime_top_bottom_rec_r", [[300,250],[336,280],[1,1]], "pc_anime_top_bottom_rec_r").addService(googletag.pubads())
+      .setTargeting("adult", "white").setCollapseEmptyDiv(true,true);googletag.enableServices();
+
+      googletag.display("pc_anime_top_bottom_rec_r");
+              });</script>
+      </div>
+    </div>  </div>
+    </div>
+</div><!-- end of contentHome -->
+</div><!-- end of contentWrapper -->
+
+  <div class="side-ad side-ad--l">
+
+        <div class="_unit " style="width:160px;display: block !important;" data-height="600">
+      <div id="pc_anime_top_side_sky_l" class="" style="width:160px;">
+        <script type='text/javascript'>
+          googletag.cmd.push(function() {
+                      var slot = googletag.defineSlot("/84947469/pc_anime_top_side_sky_l", [[160,600],[1,1]], "pc_anime_top_side_sky_l").addService(googletag.pubads())
+      .setTargeting("adult", "white")        .setCollapseEmptyDiv(true,true);googletag.enableServices();
+
+              window.MAL.SkinAd.pushSKTag("pc_anime_top_side_sky_l");
+              });</script>
+      </div>
+    </div>  </div>
+
+  <div class="side-ad side-ad--r">
+
+        <div class="_unit " style="width:160px;display: block !important;" data-height="600">
+      <div id="pc_anime_top_side_sky_r" class="" style="width:160px;">
+        <script type='text/javascript'>
+          googletag.cmd.push(function() {
+                      var slot = googletag.defineSlot("/84947469/pc_anime_top_side_sky_r", [[160,600],[1,1]], "pc_anime_top_side_sky_r").addService(googletag.pubads())
+      .setTargeting("adult", "white")        .setCollapseEmptyDiv(true,true);googletag.enableServices();
+
+              window.MAL.SkinAd.pushSKTag("pc_anime_top_side_sky_r");
+              });</script>
+      </div>
+    </div>  </div>
+
+<!--  control container height -->
+<div style="clear:both;"></div>
+
+<!-- end rightbody -->
+
+</div><!-- wrapper -->
+
+
+    <div id="ad-skin-bg-right" class="ad-skin-side-outer ad-skin-side-bg bg-right">
+    <div id="ad-skin-right" class="ad-skin-side right" style="display: none;">
+      <div id="ad-skin-right-absolute-block">
+        <div id="ad-skin-right-fixed-block"></div>
+      </div>
+    </div>
+  </div>
+</div><!-- #myanimelist -->
+
+<footer>
+  <div id="footer-block">
+    <div class="footer-link-block">
+      <p class="footer-link home di-ib">
+        <a href="https://myanimelist.net/">Home</a>
+      </p>
+      <p class="footer-link di-ib">
+        <a href="https://myanimelist.net/about.php">About</a>
+        <a href="https://myanimelist.net/pressroom">Press Room</a>
+        <a href="https://myanimelist.net/about.php?go=contact">Support</a>
+        <a href="https://myanimelist.net/advertising">Advertising</a>
+        <a href="https://myanimelist.net/forum/?topicid=515949">FAQ</a>
+        <a href="https://myanimelist.net/about/terms_of_use">Terms</a>
+        <a href="https://myanimelist.net/about/privacy_policy">Privacy</a>
+        <a href="https://myanimelist.net/about/sitemap">Sitemap</a>
+      </p>
+          </div>
+
+    <div class="footer-link-icon-block">
+            <div class="footer-social-media ac">
+        <a target="_blank" class="icon-sns icon-fb di-ib" href="https://www.facebook.com/OfficialMyAnimeList"></a>
+        <a target="_blank" class="icon-sns icon-tw di-ib" title="Follow @myanimelist on Twitter" href="https://twitter.com/myanimelist"></a>
+        <a class="icon-sns icon-gp" href="https://plus.google.com/105884801583962160252?prsrc=3" rel="publisher" target="_blank" style="text-decoration:none;">
+          <img src="https://myanimelist.cdn-dena.com/images/footer/icon-google_plus.png" alt="Google+" style="border:0;width:30px;height:30px;" />
+        </a>
+      </div>
+            <div class="footer-recommended ac">
+        <a target="_blank" class="icon-recommended icon-tokyo-otaku-mode" href="http://otakumode.com/fb/5aO">Tokyo Otaku Mode</a>
+      </div>
+            <div class="footer-competition ac">
+        <a target="_blank" class="icon-competition icon-mtb-vol5" href="https://myanimelist.net/manga_translation_battle_vol5">Manga Translation Battle vol.5</a>
+      </div>
+    </div>
+
+        <iframe class="fb-page" src="" width="450" height="154" style="border:none;overflow:hidden" scrolling="no" frameborder="0" allowTransparency="true"></iframe>
+
+    <div id="copyright">
+      MyAnimeList.net is a property of MyAnimeList, LLC. &copy;2015 All Rights Reserved.
+    </div>
+  </div>
+</footer>
+
+<div id="evolve_footer"></div>
+
+<script type="text/javascript">
+    window.MAL.magia = "06410c4e6b2518e9add8f6df0ccb2da2876bb8c980aacb43a8dcaa8153c0f92c";
+  window.MAL.madoka = "hZrDKm9k6FVRnqd3i%=K";
+
+  window.MAL.SLVK = "g4OvMLVOmEI3J8u7dt8f8+mAuualsqCo";
+  window.MAL.CDN_URL = "https://myanimelist.cdn-dena.com";
+</script>
+</body>
+</html>

--- a/test/test_anime_top_list_scraper.rb
+++ b/test/test_anime_top_list_scraper.rb
@@ -173,5 +173,60 @@ class TestAnimeTopListScraper < Test::Unit::TestCase
 
   end
 
+  def test_rank_name
+    scraper = Railgun::AnimeListScraper.new
+
+    list_type = 'all'
+    actual = scraper.rank_key(list_type)
+    expected = 'rank'
+    assert(expected, actual)
+
+    list_type = 'airing'
+    actual = scraper.rank_key(list_type)
+    expected = 'airing_rank'
+    assert(expected, actual)
+
+    list_type = 'upcoming'
+    actual = scraper.rank_key(list_type)
+    expected = 'upcoming_rank'
+    assert(expected, actual)
+
+    list_type = 'tv'
+    actual = scraper.rank_key(list_type)
+    expected = 'tv_rank'
+    assert(expected, actual)
+
+    list_type = 'movie'
+    actual = scraper.rank_key(list_type)
+    expected = 'movie_rank'
+    assert(expected, actual)
+
+    list_type = 'ova'
+    actual = scraper.rank_key(list_type)
+    expected = 'ova_rank'
+    assert(expected, actual)
+
+    list_type = 'special'
+    actual = scraper.rank_key(list_type)
+    expected = 'special_rank'
+    assert(expected, actual)
+
+    list_type = 'popular'
+    actual = scraper.rank_key(list_type)
+    expected = 'popularity_rank'
+    assert(expected, actual)
+
+    list_type = 'favorite'
+    actual = scraper.rank_key(list_type)
+    expected = 'favorited_rank'
+    assert(expected, actual)
+
+    list_type = 'thisdoesnotexist'
+    actual = scraper.rank_key(list_type)
+    expected = 'rank'
+    assert(expected, actual)
+
+  end
+
 
 end

--- a/test/test_anime_top_list_scraper.rb
+++ b/test/test_anime_top_list_scraper.rb
@@ -9,6 +9,9 @@ class TestAnimeTopListScraper < Test::Unit::TestCase
     Nokogiri::HTML(File.read("#{File.dirname(__FILE__)}/html/top_anime_response.html"))
   end
 
+  def nokogiri_for_popular_response
+    Nokogiri::HTML(File.read("#{File.dirname(__FILE__)}/html/popular_anime_response.html"))
+  end
 
   ### Tests
 
@@ -16,7 +19,7 @@ class TestAnimeTopListScraper < Test::Unit::TestCase
     nokogiri = nokogiri_for_sample_response
     scraper = Railgun::AnimeListScraper.new
 
-    result = scraper.scrape(nokogiri)
+    result = scraper.scrape(nokogiri, 'all')
 
     assert(!result.empty?)
 
@@ -75,12 +78,91 @@ class TestAnimeTopListScraper < Test::Unit::TestCase
 
       assert(!stats.nil?)
 
-      rank = stats[:rank]
+      rank = stats['rank']
 
       assert(!rank.nil?)
       assert(rank.is_a? Integer)
       assert(rank >= 0)
       
+      member_count = stats[:member_count]
+
+      assert(!member_count.nil?)
+      assert(member_count.is_a? Integer)
+      assert(member_count >= 0)
+
+    }
+
+  end
+
+  def test_scrape_popular
+    nokogiri = nokogiri_for_popular_response
+    scraper = Railgun::AnimeListScraper.new
+
+    result = scraper.scrape(nokogiri, 'popular')
+
+    assert(!result.empty?)
+
+    assert(result)
+
+    result.each { |row|
+
+      id = row[:id]
+
+      assert(!id.nil?)
+      assert(id.is_a? String)
+      assert(!id.empty?)
+
+      name = row[:name]
+
+      assert(!name.nil?)
+      assert(name.is_a? String)
+      assert(!name.empty?)
+
+      url = row[:url]
+
+      assert(!url.nil?)
+      assert(url.is_a? String)
+      assert(!url.empty?)
+      assert(url.include? id)
+
+      image_url = row[:image_url]
+
+      assert(!image_url.nil?)
+      assert(image_url.is_a? String)
+      assert(!image_url.empty?)
+
+      type = row[:type]
+
+      assert(!type.nil?)
+      assert(type.is_a? String)
+      assert(!type.empty?)
+
+      episodes = row[:episodes]
+
+      assert(!episodes.nil?)
+      assert(episodes.is_a? Integer)
+      assert(episodes >= 0)
+
+      start_date = row[:start_date]
+
+      assert(!start_date.nil?)
+      assert(start_date.is_a? String)
+
+      end_date = row[:end_date]
+
+      assert(!end_date.nil?)
+      assert(end_date.is_a? String)
+
+      stats = row[:stats]
+
+      assert(!stats.nil?)
+
+      rank = stats['popularity_rank']
+
+      assert(!rank.nil?)
+      assert(rank.is_a? Integer)
+      assert(rank >= 0)
+
       member_count = stats[:member_count]
 
       assert(!member_count.nil?)

--- a/test/test_mal_network_service.rb
+++ b/test/test_mal_network_service.rb
@@ -129,7 +129,7 @@ class TestMALNetworkService < Test::Unit::TestCase
     type = 'popular'
     page += 1
 
-    expected = 'https://myanimelist.net/topanime.php?type=popular&page=7'
+    expected = 'https://myanimelist.net/topanime.php?type=bypopularity&page=7'
     actual = Railgun::MALNetworkService.anime_rank_request(type, page)
 
     assert_equal(expected, actual)


### PR DESCRIPTION
This also changes the way rank types are defined in the stats block. The stat passed in will be returned with the appropriate key in order to comply with API coherence in resource-specific endpoints.